### PR TITLE
Some API Update

### DIFF
--- a/docs/zh-cn/changelog.md
+++ b/docs/zh-cn/changelog.md
@@ -12,6 +12,12 @@
     
     * 新增 `name_map`， [允许用户采用自己地图名称](http://echarts.baidu.com/option.html#series-map.nameMap)。
 
+    #### Changed
+
+    * `Chart.render_embed` 返回 `jinja2.Markup` 实例
+    * `Base.show_config` 重命名为 `Base.print_echarts_options`
+    * 移除 `EchartsEnvironment.configure_pyecharts` 方法
+
 * ### version 0.3.2 2018.02.26
 
     从此版本开始，将不再自带地图 js 文件。有需要的开发人员，请自选安装。

--- a/pyecharts/base.py
+++ b/pyecharts/base.py
@@ -2,6 +2,8 @@
 
 import uuid
 
+from jinja2 import Markup
+
 import pyecharts.constants as constants
 import pyecharts.engine as engine
 import pyecharts.utils as utils
@@ -70,7 +72,7 @@ class Base(object):
                              chart_id=self._chart_id,
                              my_width=self.width,
                              my_height=self.height)
-        return html
+        return Markup(html)
 
     def get_js_dependencies(self):
         """ 声明所有的 js 文件路径

--- a/pyecharts/base.py
+++ b/pyecharts/base.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 
 import uuid
+import warnings
 
 from jinja2 import Markup
 
@@ -57,10 +58,20 @@ class Base(object):
     def page_title(self):
         return self._page_title
 
-    def show_config(self):
+    def print_echarts_options(self):
         """ 打印输出图形所有配置项
         """
         print(utils.json_dumps(self._option, indent=4))
+
+    def show_config(self):
+        """ 打印输出图形所有配置项
+        """
+        deprecated_tpl = 'The {} is deprecated, please use {} instead!'
+        warnings.warn(
+            deprecated_tpl.format('show_config', 'print_echarts_options'),
+            DeprecationWarning
+        )
+        self.print_echarts_options()
 
     def render_embed(self):
         """ 渲染图表的所有配置项，为 web pages 服务，不过需先提供

--- a/pyecharts/custom/page.py
+++ b/pyecharts/custom/page.py
@@ -1,5 +1,7 @@
 # coding=utf-8
 
+from jinja2 import Markup
+
 import pyecharts.utils as utils
 import pyecharts.engine as engine
 from pyecharts.conf import CURRENT_CONFIG
@@ -43,7 +45,7 @@ class Page(list):
 
         :return:
         """
-        return '<br/> '.join([chart.render_embed() for chart in self])
+        return Markup('<br/> '.join([chart.render_embed() for chart in self]))
 
     def get_js_dependencies(self):
         """

--- a/pyecharts/engine.py
+++ b/pyecharts/engine.py
@@ -151,10 +151,6 @@ class EchartsEnvironment(BaseEnvironment):
             *args,
             **kwargs)
 
-    def configure_pyecharts(self, **kwargs):
-        for k, v in kwargs.items():
-            setattr(self.pyecharts_config, k, v)
-
 
 def render(template_file, notebook=False, **context):
     config = conf.CURRENT_CONFIG

--- a/test/test_bar.py
+++ b/test/test_bar.py
@@ -60,7 +60,7 @@ def test_bar_waterfall():
             is_stack=True)
     bar.add("月份", months, months_v2, is_label_show=True, is_stack=True,
             label_pos='inside')
-    bar.show_config()
+    bar.print_echarts_options()
     bar.render()
 
 

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -116,7 +116,7 @@ def test_show_config():
         with open(captured_stdout, 'w') as f:
             sys.stdout = f
             bar = create_a_bar("new")
-            bar.show_config()
+            bar.print_echarts_options()
     except Exception as e:
         # whatever happens, continue and restore stdout
         print(e)

--- a/test/test_geolines.py
+++ b/test/test_geolines.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from pyecharts import GeoLines, Style
 
-
 style = Style(
     title_top="#fff",
     title_pos="center",
@@ -49,5 +48,5 @@ def test_geolines():
     lines = GeoLines("GeoLines 示例", **style.init_style)
     lines.add("从广州出发", data_guangzhou, **style_geo)
     lines.add("从北京出发", data_beijing, **style_geo)
-    lines.show_config()
+    lines.print_echarts_options()
     lines.render()

--- a/test/test_template_function.py
+++ b/test/test_template_function.py
@@ -9,6 +9,7 @@ from nose.tools import raises
 from pyecharts.utils import get_resource_dir
 from pyecharts import Bar, Map
 from pyecharts.engine import BaseEnvironment, EchartsEnvironment
+from pyecharts.conf import PyEchartsConfig
 
 ECHARTS_ENV = EchartsEnvironment()
 
@@ -26,18 +27,22 @@ def create_demo_bar(chart_id_demo=None):
 
 
 def test_echarts_js_dependencies():
-    ECHARTS_ENV.configure_pyecharts(jshost='http://localhost/echarts')
-    tpl = ECHARTS_ENV.from_string('{{ echarts_js_dependencies(bar) }}')
+    env = EchartsEnvironment(
+        pyecharts_config=PyEchartsConfig(jshost='http://localhost/echarts')
+    )
+    tpl = env.from_string('{{ echarts_js_dependencies(bar) }}')
     bar = create_demo_bar()
     html = tpl.render(bar=bar)
-    assert '<script type="text/javascript" src="http://localhost/echarts/echarts.min.js"></script>' == html # flake8: noqa
+    assert '<script type="text/javascript" src="http://localhost/echarts/echarts.min.js"></script>' == html  # flake8: noqa
 
 
 def test_echarts_js_dependencies_embed():
-    ECHARTS_ENV.configure_pyecharts(
-        jshost=get_resource_dir('templates', 'js', 'echarts'))
-    tpl = ECHARTS_ENV.from_string(
-        '{{ echarts_js_dependencies_embed("echarts") }}')
+    env = EchartsEnvironment(
+        pyecharts_config=PyEchartsConfig(
+            jshost=get_resource_dir('templates', 'js', 'echarts')
+        )
+    )
+    tpl = env.from_string('{{ echarts_js_dependencies_embed("echarts") }}')
     bar = create_demo_bar()
     html = tpl.render(bar=bar)
     assert len(html) > 0
@@ -52,17 +57,17 @@ def test_echarts_js_container():
     tpl = ECHARTS_ENV.from_string('{{ echarts_container(bar) }}')
     bar = create_demo_bar('id_demo_chart')
     html = tpl.render(bar=bar)
-    assert '<div id="id_demo_chart" style="width:800px;height:400px;"></div>' == html # flake8: noqa
+    assert '<div id="id_demo_chart" style="width:800px;height:400px;"></div>' == html  # flake8: noqa
 
     bar.width = 1024
     bar.height = 768
     html = tpl.render(bar=bar)
-    assert '<div id="id_demo_chart" style="width:1024px;height:768px;"></div>' == html # flake8: noqa
+    assert '<div id="id_demo_chart" style="width:1024px;height:768px;"></div>' == html  # flake8: noqa
 
     bar.width = '1024px'
     bar.height = '768px'
     html = tpl.render(bar=bar)
-    assert '<div id="id_demo_chart" style="width:1024px;height:768px;"></div>' == html # flake8: noqa
+    assert '<div id="id_demo_chart" style="width:1024px;height:768px;"></div>' == html  # flake8: noqa
 
 
 def test_echarts_js_content():
@@ -88,9 +93,12 @@ def test_echarts_js_in_first():
     value = [20, 190, 253, 77, 65]
     attr = ['汕头市', '汕尾市', '揭阳市', '阳江市', '肇庆市']
     map = Map("广东地图示例", width=1200, height=600)
-    map.add("", attr, value, maptype='广东', is_visualmap=True, visual_text_color='#000')
-    ECHARTS_ENV.configure_pyecharts(jshost='http://localhost/echarts')
-    tpl = ECHARTS_ENV.from_string('{{ echarts_js_dependencies(m) }}')
+    map.add("", attr, value, maptype='广东', is_visualmap=True,
+            visual_text_color='#000')
+    env = EchartsEnvironment(
+        pyecharts_config=PyEchartsConfig(jshost='http://localhost/echarts')
+    )
+    tpl = env.from_string('{{ echarts_js_dependencies(m) }}')
     html = tpl.render(m=map)
     echarts_js_pos = html.find('echarts.min.js')
     guangdong_js_pos = html.find('guangdong.js')


### PR DESCRIPTION
该 PR 将会修改 pyecharts 一些公有接口，但使用者可以非常平滑的进行迁移。

## 1 移除 `EchartsEnvironment.configure_pyecharts` 方法

由于 `EchartsEnvironment` 是一个和状态相关的对象，其上的属性在创建之后的修改将无效。

因此 在使用过程中，如果需要修改渲染引擎的配置，如修改模板文件目录，应当重新创建一个新的引擎对象，而不应当在原有的对象修改。

故，该函数将不再拥有实际意义。

## 2 `chart.render_embed` 返回 `jinja2.Markup` 实例

jinja2.Markup 是 six.text_type 的一个子类，并且增加了 `__html__` 协议。这个改变将：

- 在模板中不再需要 `safe` 过滤器而显示 HTML 代码，同时 `__html__` 是 Python web 开发中通用的做法，很多框架都支持该协议。
- 和 `echarts_*` 模板函数保持一致。

另外，虽然该函数的名称无法直接体现其功能，将不再进行重命名。第一，该函数使用版本广，不宜大变更；第二，推荐使用高基于 代码块 的 高层次模板函数。

## 3 `Base.show_config` 重命名为 `Base.print_echarts_options`

和实际内容保持一致。该变更将采用通用的废弃策略，原有的 `show_config` 将在之后的版本中移除。