### PR TITLE
修复 Timeline 中 Overlap 图的 label_color 配置项不生效的 bug

### DIFF
--- a/docs/zh-cn/changelog.md
+++ b/docs/zh-cn/changelog.md
@@ -1,7 +1,12 @@
 # 版本日志
 
 * ### version 0.4.2
-    * [issue#331](https://github.com/pyecharts/pyecharts/issues/311) Jupyter Notebook 导出为 PDF 没有图片
+
+    #### Added
+    * [issue#311](https://github.com/pyecharts/pyecharts/issues/311) 提供 Jupyter Notebook 导出为 PDF 没有图片的解决方案
+
+    #### Fixed
+    * [issue#448](https://github.com/pyecharts/pyecharts/issues/448) 修复 Timeline 中 Overlap 图的 label_color 配置项不生效的 bug
 
 * ### version 0.4.1 - 2018.03.13（Current）
 

--- a/pyecharts/custom/timeline.py
+++ b/pyecharts/custom/timeline.py
@@ -104,6 +104,7 @@ class Timeline(Base):
             data=self._time_points
         )
         self._option.get('options').append({
+            "color": chart.options.get("color"),
             "legend": chart.options.get('legend'),
             "series": chart.options.get('series'),
             "title": chart.options.get('title'),

--- a/test/test_timeline.py
+++ b/test/test_timeline.py
@@ -171,5 +171,6 @@ def test_timeline_different_legend():
     timeline.add(bar_1, '2012 年')
     timeline.add(bar_2, '2013 年')
     content = timeline._repr_html_()
+    assert '"color": [' in content
     assert "\\u6625\\u5b63a" in content      # 春季 a
     assert "\\u6625\\u5b63b" in content      # 春季 b

--- a/test/test_timeline.py
+++ b/test/test_timeline.py
@@ -171,6 +171,34 @@ def test_timeline_different_legend():
     timeline.add(bar_1, '2012 年')
     timeline.add(bar_2, '2013 年')
     content = timeline._repr_html_()
-    assert '"color": [' in content
     assert "\\u6625\\u5b63a" in content      # 春季 a
     assert "\\u6625\\u5b63b" in content      # 春季 b
+
+
+def test_timeline_label_color():
+    attr = ["{}月".format(i) for i in range(1, 7)]
+    bar = Bar("1 月份数据", "数据纯属虚构")
+    bar.add("bar", attr, [randint(10, 50) for _ in range(6)],
+            label_color=['red', '#213', 'black'])
+    line = Line()
+    line.add("line", attr, [randint(50, 80) for _ in range(6)])
+    overlap_0 = Overlap()
+    overlap_0.add(bar)
+    overlap_0.add(line)
+
+    bar_1 = Bar("2 月份数据", "数据纯属虚构")
+    bar_1.add("bar", attr, [randint(10, 50) for _ in range(6)])
+    line_1 = Line()
+    line_1.add("line", attr, [randint(50, 80) for _ in range(6)])
+    overlap_1 = Overlap()
+    overlap_1.add(bar_1)
+    overlap_1.add(line_1)
+
+    timeline = Timeline(timeline_bottom=0)
+    timeline.add(overlap_0, '1 月')
+    timeline.add(overlap_1, '2 月')
+    content = timeline._repr_html_()
+    assert '"color": [' in content
+    assert "red" in content
+    assert "#213" in content
+    assert "black" in content


### PR DESCRIPTION
本次 PR 内容，

* #448 修复 Timeline 中 Overlap 图的 label_color 配置项不生效的 bug