### PR TITLE
As js functions are allowed for echarts options, python functions are allowed in pyecharts options too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ python:
   - 2.7
 before_install:
   - pip install -r test/requirements.txt
-  - if [[ $TRAVIS_PYTHON_VERSION == "3.6" ]]; then pip install https://github.com/pyecharts/pyecharts-javascripthon/archive/master.zip; fi  
-  - if [[ $TRAVIS_PYTHON_VERSION == "3.5" ]]; then pip install https://github.com/pyecharts/pyecharts-javascripthon/archive/master.zip; fi  
 script:
   - python setup.py install
   - make tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ python:
   - 2.7
 before_install:
   - pip install -r test/requirements.txt
+  - if [[ $TRAVIS_PYTHON_VERSION == "3.6" ]]; then pip install https://github.com/pyecharts/pyecharts-javascripthon/archive/master.zip; fi  
+  - if [[ $TRAVIS_PYTHON_VERSION == "3.5" ]]; then pip install https://github.com/pyecharts/pyecharts-javascripthon/archive/master.zip; fi  
 script:
   - python setup.py install
   - make tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@ install:
   - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
   - cd test
   - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
+  - "%PYTHON%\\python.exe -m pip install https://github.com/pyecharts/pyecharts-javascripthon/archive/master.zip"
   - "%PYTHON%\\python.exe -m pip install mock"
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,8 @@ install:
   - cd test
   - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
   - "%PYTHON%\\python.exe -m pip install mock"
-  - if [%PYTHON_VERSION%]==[3.5] "%PYTHON%\\python.exe -m pip install https://github.com/pyecharts/pyecharts-javascripthon/archive/master.zip"
-  - if [%PYTHON_VERSION%]==[3.6] "%PYTHON%\\python.exe -m pip install https://github.com/pyecharts/pyecharts-javascripthon/archive/master.zip"
+  - if "%PYTHON_VERSION%" == "3.5" "%PYTHON%\\python.exe -m pip install https://github.com/pyecharts/pyecharts-javascripthon/archive/master.zip"
+  - if "%PYTHON_VERSION%" == "3.6" "%PYTHON%\\python.exe -m pip install https://github.com/pyecharts/pyecharts-javascripthon/archive/master.zip"
 build: off
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,8 @@ install:
   - cd test
   - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
   - "%PYTHON%\\python.exe -m pip install mock"
-  - if "%PYTHON_VERSION%" == "3.5" "%PYTHON%\\python.exe -m pip install https://github.com/pyecharts/pyecharts-javascripthon/archive/master.zip"
-  - if "%PYTHON_VERSION%" == "3.6" "%PYTHON%\\python.exe -m pip install https://github.com/pyecharts/pyecharts-javascripthon/archive/master.zip"
+  - if "%PYTHON_VERSION%" == "3.5" %PYTHON%\\python.exe -m pip install https://github.com/pyecharts/pyecharts-javascripthon/archive/master.zip
+  - if "%PYTHON_VERSION%" == "3.6" %PYTHON%\\python.exe -m pip install https://github.com/pyecharts/pyecharts-javascripthon/archive/master.zip
 build: off
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,6 @@ install:
   - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
   - cd test
   - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
-  - "%PYTHON%\\python.exe -m pip install https://github.com/pyecharts/pyecharts-javascripthon/archive/master.zip"
   - "%PYTHON%\\python.exe -m pip install mock"
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,15 +2,19 @@ environment:
 
   matrix:
     - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7"
     - PYTHON: "C:\\Python35-x64"
+      PYTHON_VERSION: "3.5"
     - PYTHON: "C:\\Python36-x64"
+      PYTHON_VERSION: "3.6"
 
 install:
   - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
   - cd test
   - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
   - "%PYTHON%\\python.exe -m pip install mock"
-
+  - if [%PYTHON_VERSION%]==[3.5] "%PYTHON%\\python.exe -m pip install https://github.com/pyecharts/pyecharts-javascripthon/archive/master.zip"
+  - if [%PYTHON_VERSION%]==[3.6] "%PYTHON%\\python.exe -m pip install https://github.com/pyecharts/pyecharts-javascripthon/archive/master.zip"
 build: off
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,7 @@ install:
   - cd test
   - "%PYTHON%\\python.exe -m pip install -r requirements.txt"
   - "%PYTHON%\\python.exe -m pip install mock"
-  - if "%PYTHON_VERSION%" == "3.5" %PYTHON%\\python.exe -m pip install https://github.com/pyecharts/pyecharts-javascripthon/archive/master.zip
-  - if "%PYTHON_VERSION%" == "3.6" %PYTHON%\\python.exe -m pip install https://github.com/pyecharts/pyecharts-javascripthon/archive/master.zip
+
 build: off
 
 test_script:

--- a/docs/zh-cn/charts.md
+++ b/docs/zh-cn/charts.md
@@ -139,6 +139,20 @@
     * 'log'：对数轴。适用于对数数据。
 * xaxis_rotate -> int  
     x 轴刻度标签旋转的角度，在类目轴的类目标签显示不下的时候可以通过旋转防止标签之间重叠。默认为 0，即不旋转。旋转的角度从 -90 度到 90 度。
+* xaxis_formatter -> str | function  
+    x 轴标签格式器，如 '天'，则 x 轴的标签为数据加'天'(3 天，4 天),默认为 ""
+
+```
+from pyecharts_javascripthon import Date
+
+def xaxis_formatter(value, index):
+    date = Date(value)
+    texts = [(date.getMonth() + 1), date.getDate()];
+    if index == 0:
+        texts.unshift(date.getYear())
+    return '/'.join(texts)
+```
+
 * y_axis -> list  
     y 坐标轴数据
 * yaxis_interval -> int  

--- a/docs/zh-cn/charts.md
+++ b/docs/zh-cn/charts.md
@@ -2225,6 +2225,27 @@ add(name, data,
     是否显示极坐标系的角度轴，默认为 True
 * is_radiusaxis_show -> bool  
     是否显示极坐标系的径向轴，默认为 True
+* param render_item -> function
+    开发者自己提供图形渲染的逻辑, 这个渲染逻辑一般命名为 render_item
+
+```python
+def render_item(params, api):
+    values = [api.value(0), api.value(1)]
+    coord = api.coord(values)
+    size = api.size([1, 1], values)
+    return {
+        "type": 'sector',
+        "shape": {
+            "cx": params.coordSys.cx,
+            "cy": params.coordSys.cy,
+            "r0": coord[2] - size[0] / 2,
+            "r": coord[2] + size[0] / 2,
+            "startAngle": coord[3] - size[1] / 2,
+            "endAngle": coord[3] + size[1] / 2,
+        },
+        "style": api.style({"fill": api.visual('color')}),
+    }
+```
 
 ```python
 from pyecharts import Polar

--- a/docs/zh-cn/charts.md
+++ b/docs/zh-cn/charts.md
@@ -149,8 +149,20 @@
     因为 splitNumber 是预估的值，实际根据策略计算出来的刻度可能无法达到想要的效果，这时候可以使用 interval 配合 min、max 强制设定刻度划分。在类目轴中无效。
 * yaxis_margin -> int  
     y 轴刻度标签与轴线之间的距离。默认为 8
-* yaxis_formatter -> str  
+* yaxis_formatter -> str | function  
     y 轴标签格式器，如 '天'，则 y 轴的标签为数据加'天'(3 天，4 天),默认为 ""
+
+```
+from pyecharts_javascripthon import Date
+
+def yaxis_formatter(value, index):
+    date = Date(value)
+    texts = [(date.getMonth() + 1), date.getDate()];
+    if index == 0:
+        texts.unshift(date.getYear())
+    return '/'.join(texts)
+```
+
 * yaxis_name -> str  
     y 轴名称
 * yaxis_name_size -> int  
@@ -236,13 +248,45 @@
     是否随机排列颜色列表，默认为 False
 * label_color -> list  
     自定义标签颜色。全局颜色列表，所有图表的图例颜色均在这里修改。如 Bar 的柱状颜色，Line 的线条颜色等等。
-* label_formatter -> str  
+* label_formatter -> str | function
     模板变量有 {a}, {b}，{c}，{d}，{e}，分别表示系列名，数据名，数据值等。使用示例，如 `label_formatter='{a}'`  
     在 trigger 为 'axis' 的时候，会有多个系列的数据，此时可以通过 {a0}, {a1}, {a2} 这种后面加索引的方式表示系列的索引。不同图表类型下的 {a}，{b}，{c}，{d} 含义不一样。 其中变量 {a}, {b}, {c}, {d} 在不同图表类型下代表数据含义为：
     * 折线（区域）图、柱状（条形）图、K线图 : {a}（系列名称），{b}（类目值），{c}（数值）, {d}（无）
     * 散点图（气泡）图 : {a}（系列名称），{b}（数据名称），{c}（数值数组）, {d}（无）
     * 地图 : {a}（系列名称），{b}（区域名称），{c}（合并数值）, {d}（无）
     * 饼图、仪表盘、漏斗图: {a}（系列名称），{b}（数据项名称），{c}（数值）, {d}（百分比）
+
+
+回调函数
+
+```
+def label_formatter(params):
+    ...
+```
+
+回调函数格式：
+(params: Object|Array) => string
+参数 params 是 formatter 需要的单个数据集。格式如下：
+{
+    componentType: 'series',
+    // 系列类型
+    seriesType: string,
+    // 系列在传入的 option.series 中的 index
+    seriesIndex: number,
+    // 系列名称
+    seriesName: string,
+    // 数据名，类目名
+    name: string,
+    // 数据在传入的 data 数组中的 index
+    dataIndex: number,
+    // 传入的原始数据项
+    data: Object,
+    // 传入的数据值
+    value: number|Array,
+    // 数据图形的颜色
+    color: string,
+
+}
 
 **Note：** is_random 可随机打乱图例颜色列表，算是切换风格？建议试一试！
 
@@ -397,13 +441,47 @@
     * 'line': 直线指示器
     * 'shadow': 阴影指示器
     * 'cross': 十字准星指示器。其实是种简写，表示启用两个正交的轴的 axisPointer。
-* tooltip_formatter -> str  
+* tooltip_formatter -> str | function
     模板变量有 {a}, {b}，{c}，{d}，{e}，分别表示系列名，数据名，数据值等。  
     在 trigger 为 'axis' 的时候，会有多个系列的数据，此时可以通过 {a0}, {a1}, {a2} 这种后面加索引的方式表示系列的索引。不同图表类型下的 {a}，{b}，{c}，{d} 含义不一样。 其中变量 {a}, {b}, {c}, {d} 在不同图表类型下代表数据含义为：
     * 折线（区域）图、柱状（条形）图、K线图 : {a}（系列名称），{b}（类目值），{c}（数值）, {d}（无）
     * 散点图（气泡）图 : {a}（系列名称），{b}（数据名称），{c}（数值数组）, {d}（无）
     * 地图 : {a}（系列名称），{b}（区域名称），{c}（合并数值）, {d}（无）
     * 饼图、仪表盘、漏斗图: {a}（系列名称），{b}（数据项名称），{c}（数值）, {d}（百分比）
+
+回调函数格式：
+
+```
+def tooltip_formatter(params):
+    ...
+```
+
+(params: Object|Array, ticket: string, callback: (ticket: string, html: string)) => string
+第一个参数 params 是 formatter 需要的数据集。格式如下：
+{
+    componentType: 'series',
+    // 系列类型
+    seriesType: string,
+    // 系列在传入的 option.series 中的 index
+    seriesIndex: number,
+    // 系列名称
+    seriesName: string,
+    // 数据名，类目名
+    name: string,
+    // 数据在传入的 data 数组中的 index
+    dataIndex: number,
+    // 传入的原始数据项
+    data: Object,
+    // 传入的数据值
+    value: number|Array,
+    // 数据图形的颜色
+    color: string,
+
+    // 饼图的百分比
+    percent: number,
+
+}
+
 * tooltip_text_color -> str  
     提示框字体颜色，默认为 '#fff'
 * tooltip_font_size -> int  

--- a/docs/zh-cn/charts.md
+++ b/docs/zh-cn/charts.md
@@ -2223,6 +2223,10 @@ add(name, data,
     坐标轴刻度范围。默认值为 [None, None]。
 * is_angleaxis_show -> bool  
     是否显示极坐标系的角度轴，默认为 True
+* radiusaxis_z_index -> int
+    radius 轴的 z 指数，默认为 50
+* angleaxis_z_index -> int
+    angel 轴的 z 指数，默认为 50
 * is_radiusaxis_show -> bool  
     是否显示极坐标系的径向轴，默认为 True
 * param render_item -> function

--- a/pyecharts/base.py
+++ b/pyecharts/base.py
@@ -5,9 +5,10 @@ import warnings
 
 from jinja2 import Markup
 
-import pyecharts.constants as constants
-import pyecharts.engine as engine
 import pyecharts.utils as utils
+import pyecharts.engine as engine
+import pyecharts.constants as constants
+import pyecharts.javascript as javascript
 import pyecharts.exceptions as exceptions
 from pyecharts.conf import CURRENT_CONFIG
 
@@ -65,7 +66,7 @@ class Base(object):
     def print_echarts_options(self):
         """ 打印输出图形所有配置项
         """
-        print(utils.json_dumps(self._option, indent=4))
+        print(javascript.translate_options(self._option, indent=4))
 
     def show_config(self):
         """ 打印输出图形所有配置项

--- a/pyecharts/charts/polar.py
+++ b/pyecharts/charts/polar.py
@@ -65,6 +65,8 @@ class Polar(Chart):
             是否显示极坐标系的角度轴，默认为 True。
         :param is_radiusaxis_show:
             是否显示极坐标系的径向轴，默认为 True。
+        :param render_item:
+            开发者自己提供图形渲染的逻辑
         :param kwargs:
         """
         chart = get_all_options(**kwargs)

--- a/pyecharts/charts/polar.py
+++ b/pyecharts/charts/polar.py
@@ -2,6 +2,7 @@
 
 from pyecharts.chart import Chart
 from pyecharts.option import get_all_options
+import pyecharts.javascript as javascript
 
 
 class Polar(Chart):
@@ -29,6 +30,7 @@ class Polar(Chart):
               axis_range=None,
               is_angleaxis_show=True,
               is_radiusaxis_show=True,
+              render_item=None,
               **kwargs):
         """
 
@@ -127,6 +129,27 @@ class Polar(Chart):
                 "name": name,
                 "coordinateSystem": 'polar',
                 "data": data,
+            })
+            self._option.update(radiusAxis={
+                "show": is_radiusaxis_show,
+            })
+            self._option.update(
+                angleAxis={
+                    "show": is_angleaxis_show,
+                    "type": polar_type,
+                    "data": radius_data,
+                    "z": 50,
+                    "startAngle": start_angle,
+                    "splitLine": chart['split_line']
+                })
+        elif type == "custom":
+            assert render_item is not None
+            self._option.get('series').append({
+                "type": "custom",
+                "name": name,
+                "coordinateSystem": 'polar',
+                "data": data,
+                "renderItem": javascript.add_a_new_function(render_item)
             })
             self._option.update(radiusAxis={
                 "show": is_radiusaxis_show,

--- a/pyecharts/charts/polar.py
+++ b/pyecharts/charts/polar.py
@@ -30,6 +30,8 @@ class Polar(Chart):
               axis_range=None,
               is_angleaxis_show=True,
               is_radiusaxis_show=True,
+              radiusaxis_z_index=50,
+              angleaxis_z_index=50,
               render_item=None,
               **kwargs):
         """
@@ -65,6 +67,10 @@ class Polar(Chart):
             是否显示极坐标系的角度轴，默认为 True。
         :param is_radiusaxis_show:
             是否显示极坐标系的径向轴，默认为 True。
+        :param radiusaxis_z_index:
+            radius 轴的 z 指数，默认为 50
+        :param angleaxis_z_index:
+            angel 轴的 z 指数，默认为 50
         :param render_item:
             开发者自己提供图形渲染的逻辑
         :param kwargs:
@@ -121,7 +127,7 @@ class Polar(Chart):
                 radiusAxis={
                     "type": polar_type,
                     "data": radius_data,
-                    "z": 50,
+                    "z": radiusaxis_z_index,
                 })
 
         elif type == "barAngle":
@@ -140,7 +146,7 @@ class Polar(Chart):
                     "show": is_angleaxis_show,
                     "type": polar_type,
                     "data": radius_data,
-                    "z": 50,
+                    "z": angleaxis_z_index,
                     "startAngle": start_angle,
                     "splitLine": chart['split_line']
                 })
@@ -153,18 +159,6 @@ class Polar(Chart):
                 "data": data,
                 "renderItem": javascript.add_a_new_function(render_item)
             })
-            self._option.update(radiusAxis={
-                "show": is_radiusaxis_show,
-            })
-            self._option.update(
-                angleAxis={
-                    "show": is_angleaxis_show,
-                    "type": polar_type,
-                    "data": radius_data,
-                    "z": 50,
-                    "startAngle": start_angle,
-                    "splitLine": chart['split_line']
-                })
 
         if type not in ("barAngle", "barRadius"):
             self._option.update(
@@ -187,7 +181,8 @@ class Polar(Chart):
                     "min": _amin,
                     "max": _amax,
                     "axisLine": chart['axis_line'],
-                    "axisLabel": {"rotate": rotate_step}
+                    "axisLabel": {"rotate": rotate_step},
+                    "z": radiusaxis_z_index
                 }
             )
         self._option.update(polar={})

--- a/pyecharts/constants.py
+++ b/pyecharts/constants.py
@@ -1,7 +1,9 @@
 # coding=utf-8
 from __future__ import unicode_literals
+import sys
 
 
+PY35_ABOVE = sys.version_info[0] == 3 and sys.version_info[1] > 4
 CANVAS_RENDERER = "canvas"
 SVG_RENDERER = "svg"
 PAGE_TITLE = "Echarts"
@@ -15,7 +17,8 @@ DEFAULT_HTML = 'html'
 JUPYTER_PRESENTATIONS = [SVG, PNG, JPEG, DEFAULT_HTML]
 ENVIRONMENT_PLUGIN_TYPE = 'pyecharts_environment'
 JS_EXTENSION_PLUGIN_TYPE = 'pyecharts_js_extension'
-ENCODER_PLUGIN_TYPE = 'pyecharts_json_encoder'
+
+ERROR_MESSAGE = "You need python 3.5+ and pyecharts-javascripthon"
 
 SYMBOL = {
     "plane": 'path://M1705.06,1318.313v-89.254l-319.9-221.799l0.073-208.'

--- a/pyecharts/constants.py
+++ b/pyecharts/constants.py
@@ -14,6 +14,7 @@ DEFAULT_HTML = 'html'
 JUPYTER_PRESENTATIONS = [SVG, PNG, JPEG, DEFAULT_HTML]
 ENVIRONMENT_PLUGIN_TYPE = 'pyecharts_environment'
 JS_EXTENSION_PLUGIN_TYPE = 'pyecharts_js_extension'
+ENCODER_PLUGIN_TYPE = 'pyecharts_json_encoder'
 
 SYMBOL = {
     "plane": 'path://M1705.06,1318.313v-89.254l-319.9-221.799l0.073-208.'

--- a/pyecharts/constants.py
+++ b/pyecharts/constants.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from __future__ import unicode_literals
 
+
 CANVAS_RENDERER = "canvas"
 SVG_RENDERER = "svg"
 PAGE_TITLE = "Echarts"

--- a/pyecharts/engine.py
+++ b/pyecharts/engine.py
@@ -90,10 +90,10 @@ def generate_js_content(*charts):
             chart_id=chart.chart_id,
             renderer=chart.renderer,
             custom_function='',
-            options=utils.json_dumps(chart.options, indent=4)
+            options=javascript.translate_options(chart.options, indent=4)
         )
         if javascript.has_functions():
-            kwargs['custom_function'] = javascript.compile()
+            kwargs['custom_function'] = javascript.translate_python_functions()
         js_content = CHART_CONFIG_FORMATTER.format(**kwargs)
 
         contents.append(js_content)

--- a/pyecharts/engine.py
+++ b/pyecharts/engine.py
@@ -9,11 +9,9 @@ from lml.plugin import PluginManager, PluginInfo
 import pyecharts.conf as conf
 import pyecharts.utils as utils
 import pyecharts.constants as constants
+import pyecharts.exceptions as exceptions
 import pyecharts.javascript as javascript
-import sys
 
-
-PY35_ABOVE = sys.version_info[0] == 3 and sys.version_info[1] > 4
 
 LINK_SCRIPT_FORMATTER = '<script type="text/javascript" src="{}"></script>'
 EMBED_SCRIPT_FORMATTER = '<script type="text/javascript">\n{}\n</script>'
@@ -93,10 +91,13 @@ def generate_js_content(*charts):
             renderer=chart.renderer,
             options=utils.json_dumps(chart.options, indent=4)
         )
-        if PY35_ABOVE:
+        if constants.PY35_ABOVE:
             kwargs['custom_function'] = javascript.compile()
         else:
-            kwargs['custom_function'] = ''
+            if javascript.is_empty():
+                kwargs['custom_function'] = ''
+            else:
+                raise exceptions.JavascriptNotSupported(constants.ERROR_MESSAGE)
         js_content = CHART_CONFIG_FORMATTER.format(**kwargs)
 
         contents.append(js_content)

--- a/pyecharts/engine.py
+++ b/pyecharts/engine.py
@@ -9,13 +9,14 @@ from lml.plugin import PluginManager, PluginInfo
 import pyecharts.conf as conf
 import pyecharts.utils as utils
 import pyecharts.constants as constants
-
+import pyecharts.javascript as javascript
 
 LINK_SCRIPT_FORMATTER = '<script type="text/javascript" src="{}"></script>'
 EMBED_SCRIPT_FORMATTER = '<script type="text/javascript">\n{}\n</script>'
 CHART_DIV_FORMATTER = '<div id="{chart_id}" style="width:{width};height:{height};"></div>'  # flake8: noqa
 CHART_CONFIG_FORMATTER = """
 var myChart_{chart_id} = echarts.init(document.getElementById('{chart_id}'), null, {{renderer: '{renderer}'}});
+{custom_function}
 var option_{chart_id} = {options};
 myChart_{chart_id}.setOption(option_{chart_id});
 """
@@ -86,6 +87,7 @@ def generate_js_content(*charts):
         js_content = CHART_CONFIG_FORMATTER.format(
             chart_id=chart.chart_id,
             renderer=chart.renderer,
+            custom_function=javascript.compile(),
             options=utils.json_dumps(chart.options, indent=4)
         )
         contents.append(js_content)

--- a/pyecharts/engine.py
+++ b/pyecharts/engine.py
@@ -10,6 +10,10 @@ import pyecharts.conf as conf
 import pyecharts.utils as utils
 import pyecharts.constants as constants
 import pyecharts.javascript as javascript
+import sys
+
+
+PY35_ABOVE = sys.version_info[0] == 3 and sys.version_info[1] > 4
 
 LINK_SCRIPT_FORMATTER = '<script type="text/javascript" src="{}"></script>'
 EMBED_SCRIPT_FORMATTER = '<script type="text/javascript">\n{}\n</script>'
@@ -84,12 +88,17 @@ def generate_js_content(*charts):
     """
     contents = []
     for chart in charts:
-        js_content = CHART_CONFIG_FORMATTER.format(
+        kwargs = dict(
             chart_id=chart.chart_id,
             renderer=chart.renderer,
-            custom_function=javascript.compile(),
             options=utils.json_dumps(chart.options, indent=4)
         )
+        if PY35_ABOVE:
+            kwargs['custom_function'] = javascript.compile()
+        else:
+            kwargs['custom_function'] = ''
+        js_content = CHART_CONFIG_FORMATTER.format(**kwargs)
+
         contents.append(js_content)
     contents = '\n'.join(contents)
     return contents

--- a/pyecharts/engine.py
+++ b/pyecharts/engine.py
@@ -93,10 +93,7 @@ def generate_js_content(*charts):
             options=utils.json_dumps(chart.options, indent=4)
         )
         if javascript.has_functions():
-            if constants.PY35_ABOVE:
-                kwargs['custom_function'] = javascript.compile()
-            else:
-                raise exceptions.JavascriptNotSupported(constants.ERROR_MESSAGE)
+            kwargs['custom_function'] = javascript.compile()
         js_content = CHART_CONFIG_FORMATTER.format(**kwargs)
 
         contents.append(js_content)

--- a/pyecharts/engine.py
+++ b/pyecharts/engine.py
@@ -91,11 +91,11 @@ def generate_js_content(*charts):
             renderer=chart.renderer,
             options=utils.json_dumps(chart.options, indent=4)
         )
-        if constants.PY35_ABOVE:
-            kwargs['custom_function'] = javascript.compile()
+        if javascript.is_empty():
+            kwargs['custom_function'] = ''
         else:
-            if javascript.is_empty():
-                kwargs['custom_function'] = ''
+            if constants.PY35_ABOVE:
+                kwargs['custom_function'] = javascript.compile()
             else:
                 raise exceptions.JavascriptNotSupported(constants.ERROR_MESSAGE)
         js_content = CHART_CONFIG_FORMATTER.format(**kwargs)

--- a/pyecharts/engine.py
+++ b/pyecharts/engine.py
@@ -89,11 +89,10 @@ def generate_js_content(*charts):
         kwargs = dict(
             chart_id=chart.chart_id,
             renderer=chart.renderer,
+            custom_function='',
             options=utils.json_dumps(chart.options, indent=4)
         )
-        if javascript.is_empty():
-            kwargs['custom_function'] = ''
-        else:
+        if javascript.has_functions():
             if constants.PY35_ABOVE:
                 kwargs['custom_function'] = javascript.compile()
             else:

--- a/pyecharts/exceptions.py
+++ b/pyecharts/exceptions.py
@@ -8,3 +8,11 @@ class InvalidRegistry(Exception):
 
 class InvalidConfiguration(Exception):
     pass
+
+
+class JavascriptNotSupported(Exception):
+    pass
+
+
+class ExtensionMissing(Exception):
+    pass

--- a/pyecharts/javascript.py
+++ b/pyecharts/javascript.py
@@ -1,0 +1,48 @@
+import sys
+
+
+PY35_ABOVE = sys.version_info[0] == 3 and sys.version_info[1] > 4
+CUSTOM_FUNCTIONS = {}
+ERROR_MESSAGE = "You need python 3.5+ and pyecharts-javascripthon"
+# to escape javascript function in
+# json dump
+FUNCTION_LEFT_ESCAPE = '"-=>'
+FUNCTION_RIGHT_ESCAPE = '<=-"'
+FUNCTION_SIGNATURE = '-=>%s<=-'
+
+
+def clear():
+    CUSTOM_FUNCTIONS.clear()
+
+
+def add_a_new_function(afunc):
+    if not PY35_ABOVE:
+        raise Exception(ERROR_MESSAGE)
+
+    CUSTOM_FUNCTIONS[afunc.__name__] = afunc
+    return FUNCTION_SIGNATURE % afunc.__name__
+
+
+def unescape_js_function(options_json):
+    unescaped_json = options_json.replace(FUNCTION_LEFT_ESCAPE, '')
+    json_with_function_names = unescaped_json.replace(
+        FUNCTION_RIGHT_ESCAPE, '')
+    return json_with_function_names
+
+
+def isEmpty():
+    return len(CUSTOM_FUNCTIONS) == 0
+
+
+def compile():
+    try:
+        from pyecharts_javascripthon import Python2Javascript
+    except ImportError:
+        raise Exception(ERROR_MESSAGE)
+
+    content = []
+    for func in CUSTOM_FUNCTIONS:
+        javascript_function = Python2Javascript.translate(
+            CUSTOM_FUNCTIONS[func])
+        content.append(javascript_function)
+    return ''.join(content)

--- a/pyecharts/javascript.py
+++ b/pyecharts/javascript.py
@@ -26,8 +26,8 @@ def unescape_js_function(options_json):
     return json_with_function_names
 
 
-def is_empty():
-    return len(CUSTOM_FUNCTIONS) == 0
+def has_functions():
+    return len(CUSTOM_FUNCTIONS) > 0
 
 
 def compile():

--- a/pyecharts/javascript.py
+++ b/pyecharts/javascript.py
@@ -1,3 +1,7 @@
+# coding=utf-8
+import json
+import datetime
+
 import pyecharts.constants as constants
 import pyecharts.exceptions as exceptions
 
@@ -17,6 +21,7 @@ def clear():
 def add_a_new_function(afunc):
     if not constants.PY35_ABOVE:
         raise exceptions.JavascriptNotSupported(constants.ERROR_MESSAGE)
+
     CUSTOM_FUNCTIONS[afunc.__name__] = afunc
     return FUNCTION_SIGNATURE % afunc.__name__
 
@@ -32,7 +37,7 @@ def has_functions():
     return len(CUSTOM_FUNCTIONS) > 0
 
 
-def compile():
+def translate_python_functions():
     try:
         from pyecharts_javascripthon import Python2Javascript
     except ImportError:
@@ -44,3 +49,37 @@ def compile():
             CUSTOM_FUNCTIONS[func])
         content.append(javascript_function)
     return ''.join(content)
+
+
+class UnknownTypeEncoder(json.JSONEncoder):
+    """
+    UnknownTypeEncoder`类用于处理数据的编码，使其能够被正常的序列化
+    """
+
+    def default(self, obj):
+        if isinstance(obj, (datetime.datetime, datetime.date)):
+            return obj.isoformat()
+        else:
+            # Pandas and Numpy lists
+            try:
+                return obj.astype(float).tolist()
+            except Exception:
+                try:
+                    return obj.astype(str).tolist()
+                except Exception:
+                    return json.JSONEncoder.default(self, obj)
+
+
+def translate_options(data, indent=0):
+    """ json 序列化编码处理
+
+    :param data: 字典数据
+    :param indent: 缩进量
+    """
+    options_in_json = json.dumps(data, indent=indent, cls=UnknownTypeEncoder)
+    if has_functions():
+        options_with_js_functions = unescape_js_function(
+            options_in_json)
+        return options_with_js_functions
+    else:
+        return options_in_json

--- a/pyecharts/javascript.py
+++ b/pyecharts/javascript.py
@@ -1,5 +1,8 @@
+import pyecharts.constants as constants
+import pyecharts.exceptions as exceptions
+
+
 CUSTOM_FUNCTIONS = {}
-ERROR_MESSAGE = "You need python 3.5+ and pyecharts-javascripthon"
 # to escape javascript function in
 # json dump
 FUNCTION_LEFT_ESCAPE = '"-=>'
@@ -23,7 +26,7 @@ def unescape_js_function(options_json):
     return json_with_function_names
 
 
-def isEmpty():
+def is_empty():
     return len(CUSTOM_FUNCTIONS) == 0
 
 
@@ -31,7 +34,7 @@ def compile():
     try:
         from pyecharts_javascripthon import Python2Javascript
     except ImportError:
-        raise Exception(ERROR_MESSAGE)
+        raise exceptions.ExtensionMissing(constants.ERROR_MESSAGE)
 
     content = []
     for func in CUSTOM_FUNCTIONS:

--- a/pyecharts/javascript.py
+++ b/pyecharts/javascript.py
@@ -11,7 +11,7 @@ CUSTOM_FUNCTIONS = {}
 # json dump
 FUNCTION_LEFT_ESCAPE = '"-=>'
 FUNCTION_RIGHT_ESCAPE = '<=-"'
-FUNCTION_SIGNATURE = '-=>%s<=-'
+FUNCTION_SIGNATURE = '-=>{0}<=-'
 
 
 def clear():
@@ -23,7 +23,7 @@ def add_a_new_function(afunc):
         raise exceptions.JavascriptNotSupported(constants.ERROR_MESSAGE)
 
     CUSTOM_FUNCTIONS[afunc.__name__] = afunc
-    return FUNCTION_SIGNATURE % afunc.__name__
+    return FUNCTION_SIGNATURE.format(afunc.__name__)
 
 
 def unescape_js_function(options_json):

--- a/pyecharts/javascript.py
+++ b/pyecharts/javascript.py
@@ -1,7 +1,3 @@
-import sys
-
-
-PY35_ABOVE = sys.version_info[0] == 3 and sys.version_info[1] > 4
 CUSTOM_FUNCTIONS = {}
 ERROR_MESSAGE = "You need python 3.5+ and pyecharts-javascripthon"
 # to escape javascript function in
@@ -16,9 +12,6 @@ def clear():
 
 
 def add_a_new_function(afunc):
-    if not PY35_ABOVE:
-        raise Exception(ERROR_MESSAGE)
-
     CUSTOM_FUNCTIONS[afunc.__name__] = afunc
     return FUNCTION_SIGNATURE % afunc.__name__
 

--- a/pyecharts/javascript.py
+++ b/pyecharts/javascript.py
@@ -15,6 +15,8 @@ def clear():
 
 
 def add_a_new_function(afunc):
+    if not constants.PY35_ABOVE:
+        raise exceptions.JavascriptNotSupported(constants.ERROR_MESSAGE)
     CUSTOM_FUNCTIONS[afunc.__name__] = afunc
     return FUNCTION_SIGNATURE % afunc.__name__
 

--- a/pyecharts/option.py
+++ b/pyecharts/option.py
@@ -2,6 +2,9 @@
 from __future__ import unicode_literals
 
 import random
+import types
+
+import pyecharts.javascript as javascript
 
 fs = []
 SYMBOLS = ('rect', 'roundRect', 'triangle', 'diamond', 'pin', 'arrow')
@@ -81,11 +84,14 @@ def label(type=None,
             }}
     }
 
+    _tmp_formatter = label_formatter
     if label_formatter is None:
         if type == "pie":
-            label_formatter = "{b}: {d}%"
+            _tmp_formatter = "{b}: {d}%"
+    elif isinstance(label_formatter, types.FunctionType):
+        _tmp_formatter = javascript.add_a_new_function(label_formatter)
     if type != "graph":
-        _label.get("normal").update(formatter=label_formatter)
+        _label.get("normal").update(formatter=_tmp_formatter)
     return _label
 
 

--- a/pyecharts/option.py
+++ b/pyecharts/option.py
@@ -245,6 +245,7 @@ def xy_axis(type=None,
             xaxis_pos=None,
             xaxis_label_textsize=12,
             xaxis_label_textcolor="#000",
+            xaxis_formatter=None,
             yaxis_margin=8,
             yaxis_name_size=14,
             yaxis_name_gap=25,
@@ -383,6 +384,14 @@ def xy_axis(type=None,
         是否显示 y 轴网格线，默认为 True。
     :param kwargs:
     """
+    if isinstance(xaxis_formatter, types.FunctionType):
+        xaxis_formatter = javascript.add_a_new_function(xaxis_formatter)
+
+    if isinstance(yaxis_formatter, types.FunctionType):
+        yaxis_formatter = javascript.add_a_new_function(yaxis_formatter)
+    else:
+        yaxis_formatter = "{value} " + yaxis_formatter
+
     _xAxis = {
         "name": xaxis_name,
         "show": is_xaxis_show,
@@ -391,6 +400,7 @@ def xy_axis(type=None,
         "nameTextStyle": {"fontSize": xaxis_name_size},
         "axisLabel": {
             "interval": xaxis_interval,
+            "formatter": xaxis_formatter,
             "rotate": xaxis_rotate,
             "margin": xaxis_margin,
             "textStyle": {
@@ -414,7 +424,7 @@ def xy_axis(type=None,
         "nameGap": yaxis_name_gap,
         "nameTextStyle": {"fontSize": yaxis_name_size},
         "axisLabel": {
-            "formatter": "{value} " + yaxis_formatter,
+            "formatter": yaxis_formatter,
             "rotate": yaxis_rotate,
             "interval": yaxis_interval,
             "margin": yaxis_margin,
@@ -1138,17 +1148,20 @@ def tooltip(type=None,
     :param tooltip_border_width:
         提示框浮层的边框宽。默认为 0
     """
+    _tmp_formatter = tooltip_formatter
     if tooltip_formatter is None:
         if type == "gauge":
-            tooltip_formatter = "{a} <br/>{b} : {c}%"
+            _tmp_formatter = "{a} <br/>{b} : {c}%"
         elif type == "geo":
-            tooltip_formatter = "{b}: {c}"
+            _tmp_formatter = "{b}: {c}"
+    elif isinstance(tooltip_formatter, types.FunctionType):
+        _tmp_formatter = javascript.add_a_new_function(tooltip_formatter)
 
     _tooltip = {
         "trigger": tooltip_tragger,
         "triggerOn": tooltip_tragger_on,
         "axisPointer": {"type": tooltip_axispointer_type},
-        "formatter": tooltip_formatter,
+        "formatter": _tmp_formatter,
         "textStyle": {
             "color": tooltip_text_color,
             "fontSize": tooltip_font_size

--- a/pyecharts/utils.py
+++ b/pyecharts/utils.py
@@ -2,11 +2,7 @@
 from __future__ import unicode_literals
 
 import codecs
-import datetime
 import os
-import json
-
-import pyecharts.javascript as javascript
 
 
 def get_resource_dir(*paths):
@@ -29,40 +25,6 @@ def write_utf8_html_file(file_name, html_content):
     """
     with codecs.open(file_name, 'w+', encoding='utf-8') as f:
         f.write(html_content)
-
-
-class UnknownTypeEncoder(json.JSONEncoder):
-    """
-    UnknownTypeEncoder`类用于处理数据的编码，使其能够被正常的序列化
-    """
-
-    def default(self, obj):
-        if isinstance(obj, (datetime.datetime, datetime.date)):
-            return obj.isoformat()
-        else:
-            # Pandas and Numpy lists
-            try:
-                return obj.astype(float).tolist()
-            except Exception:
-                try:
-                    return obj.astype(str).tolist()
-                except Exception:
-                    return json.JSONEncoder.default(self, obj)
-
-
-def json_dumps(data, indent=0):
-    """ json 序列化编码处理
-
-    :param data: 字典数据
-    :param indent: 缩进量
-    """
-    options_in_json = json.dumps(data, indent=indent, cls=UnknownTypeEncoder)
-    if javascript.has_functions():
-        options_with_js_functions = javascript.unescape_js_function(
-            options_in_json)
-        return options_with_js_functions
-    else:
-        return options_in_json
 
 
 def to_css_length(x):

--- a/pyecharts/utils.py
+++ b/pyecharts/utils.py
@@ -58,8 +58,11 @@ def json_dumps(data, indent=0):
     """
     options_in_json = json.dumps(data, indent=indent, cls=UnknownTypeEncoder)
     if javascript.has_functions():
-        options_in_json = javascript.unescape_js_function(options_in_json)
-    return options_in_json
+        options_with_js_functions = javascript.unescape_js_function(
+            options_in_json)
+        return options_with_js_functions
+    else:
+        return options_in_json
 
 
 def to_css_length(x):

--- a/pyecharts/utils.py
+++ b/pyecharts/utils.py
@@ -6,6 +6,8 @@ import datetime
 import os
 import json
 
+import pyecharts.javascript as javascript
+
 
 def get_resource_dir(*paths):
     """
@@ -54,7 +56,9 @@ def json_dumps(data, indent=0):
     :param data: 字典数据
     :param indent: 缩进量
     """
-    return json.dumps(data, indent=indent, cls=UnknownTypeEncoder)
+    pure_json = json.dumps(data, indent=indent, cls=UnknownTypeEncoder)
+    json_with_function_names = javascript.unescape_js_function(pure_json)
+    return json_with_function_names
 
 
 def to_css_length(x):

--- a/pyecharts/utils.py
+++ b/pyecharts/utils.py
@@ -56,9 +56,10 @@ def json_dumps(data, indent=0):
     :param data: 字典数据
     :param indent: 缩进量
     """
-    pure_json = json.dumps(data, indent=indent, cls=UnknownTypeEncoder)
-    json_with_function_names = javascript.unescape_js_function(pure_json)
-    return json_with_function_names
+    options_in_json = json.dumps(data, indent=indent, cls=UnknownTypeEncoder)
+    if javascript.has_functions():
+        options_in_json = javascript.unescape_js_function(options_in_json)
+    return options_in_json
 
 
 def to_css_length(x):

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -9,3 +9,4 @@ mock;python_version<"3"
 echarts-countries-pypkg
 echarts-china-cities-pypkg
 echarts-china-provinces-pypkg
+https://github.com/pyecharts/pyecharts-javascripthon/archive/master.zip;python_version>="3.5"

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -9,4 +9,3 @@ mock;python_version<"3"
 echarts-countries-pypkg
 echarts-china-cities-pypkg
 echarts-china-provinces-pypkg
-https://github.com/pyecharts/pyecharts-javascripthon/archive/master.zip;python_version>="3.5"

--- a/test/test_javascript.py
+++ b/test/test_javascript.py
@@ -25,20 +25,20 @@ def test_label_formatter():
     bar.add("precipitation", attr, v1, mark_line=["average"],
             mark_point=["max", "min"], label_formatter=label_formatter)
     if PY35_ABOVE:
-        bar.render()
-        content = get_default_rendering_file_content()
-        assert 'function label_formatter(params)' in content
-        assert 'params.name + \"abc\"' in content
-        assert '"formatter": label_formatter' in content
-        os.unlink('render.html')
-    elif WINDOWS:
-        with assert_raises(exceptions.ExtensionMissing):
+        if WINDOWS:
+            with assert_raises(exceptions.ExtensionMissing):
+                bar.render()
+        else:
             bar.render()
-        javascript.clear()
+            content = get_default_rendering_file_content()
+            assert 'function label_formatter(params)' in content
+            assert 'params.name + \"abc\"' in content
+            assert '"formatter": label_formatter' in content
+            os.unlink('render.html')
     else:
         with assert_raises(exceptions.JavascriptNotSupported):
             bar.render()
-        javascript.clear()
+    javascript.clear()
 
 
 def yaxis_formatter(value, index):
@@ -52,20 +52,20 @@ def test_yaxis_formatter():
     bar.add("precipitation", attr, v1, mark_line=["average"],
             mark_point=["max", "min"], yaxis_formatter=yaxis_formatter)
     if PY35_ABOVE:
-        bar.render()
-        content = get_default_rendering_file_content()
-        assert 'function yaxis_formatter(value, index)' in content
-        assert 'value + index' in content
-        assert '"formatter": yaxis_formatter' in content
-        os.unlink('render.html')
-    elif WINDOWS:
-        with assert_raises(exceptions.ExtensionMissing):
+        if WINDOWS:
+            with assert_raises(exceptions.ExtensionMissing):
+                bar.render()
+        else:
             bar.render()
-        javascript.clear()
+            content = get_default_rendering_file_content()
+            assert 'function yaxis_formatter(value, index)' in content
+            assert 'value + index' in content
+            assert '"formatter": yaxis_formatter' in content
+            os.unlink('render.html')
     else:
         with assert_raises(exceptions.JavascriptNotSupported):
             bar.render()
-        javascript.clear()
+    javascript.clear()
 
 
 def xaxis_formatter(value, index):
@@ -79,20 +79,23 @@ def test_xaxis_formatter():
     bar.add("precipitation", attr, v1, mark_line=["average"],
             mark_point=["max", "min"], xaxis_formatter=xaxis_formatter)
     if PY35_ABOVE:
-        bar.render()
-        content = get_default_rendering_file_content()
-        assert 'function xaxis_formatter(value, index)' in content
-        assert 'value + index' in content
-        assert '"formatter": xaxis_formatter' in content
-        os.unlink('render.html')
+        if WINDOWS:
+            with assert_raises(exceptions.ExtensionMissing):
+                bar.render()
+        else:
+            bar.render()
+            content = get_default_rendering_file_content()
+            assert 'function xaxis_formatter(value, index)' in content
+            assert 'value + index' in content
+            assert '"formatter": xaxis_formatter' in content
+            os.unlink('render.html')
     elif WINDOWS:
         with assert_raises(exceptions.ExtensionMissing):
             bar.render()
-        javascript.clear()
     else:
         with assert_raises(exceptions.JavascriptNotSupported):
             bar.render()
-        javascript.clear()
+    javascript.clear()
 
 
 def tooltip_formatter(params):
@@ -106,17 +109,20 @@ def test_tooltip_formatter():
     bar.add("precipitation", attr, v1, mark_line=["average"],
             mark_point=["max", "min"], tooltip_formatter=tooltip_formatter)
     if PY35_ABOVE:
-        bar.render()
-        content = get_default_rendering_file_content()
-        assert 'function tooltip_formatter(params)' in content
-        assert 'params.name + \"abc\"' in content
-        assert '"formatter": tooltip_formatter' in content
-        os.unlink('render.html')
+        if WINDOWS:
+            with assert_raises(exceptions.ExtensionMissing):
+                bar.render()
+        else:
+            bar.render()
+            content = get_default_rendering_file_content()
+            assert 'function tooltip_formatter(params)' in content
+            assert 'params.name + \"abc\"' in content
+            assert '"formatter": tooltip_formatter' in content
+            os.unlink('render.html')
     elif WINDOWS:
         with assert_raises(exceptions.ExtensionMissing):
             bar.render()
-        javascript.clear()
     else:
         with assert_raises(exceptions.JavascriptNotSupported):
             bar.render()
-        javascript.clear()
+    javascript.clear()

--- a/test/test_javascript.py
+++ b/test/test_javascript.py
@@ -55,6 +55,7 @@ def test_yaxis_formatter():
             bar.render()
         javascript.clear()
 
+
 def xaxis_formatter(value, index):
     return value + index
 

--- a/test/test_javascript.py
+++ b/test/test_javascript.py
@@ -6,7 +6,7 @@ import numpy as np
 
 from nose.tools import assert_raises, eq_
 
-from pyecharts import Bar
+from pyecharts import Bar, Polar
 from pyecharts.constants import PY35_ABOVE
 import pyecharts.exceptions as exceptions
 import pyecharts.javascript as javascript
@@ -91,6 +91,38 @@ def test_tooltip_formatter():
         assert 'params.name + \"abc\"' in content
         assert '"formatter": tooltip_formatter' in content
         os.unlink('render.html')
+
+
+def custom_polar_render_item(params, api):
+    return 'test'
+
+
+def test_polar_draw_snail():
+    data = []
+    polar = Polar("polar test")
+    if PY35_ABOVE:
+        polar.add("", data, symbol_size=0, symbol='circle',
+                  area_color="#f3c5b3", type='custom',
+                  render_item=custom_polar_render_item,
+                  area_opacity=0.5, is_angleaxis_show=False)
+        if WINDOWS:
+            with assert_raises(exceptions.ExtensionMissing):
+                polar.render()
+        else:
+            polar.render()
+            content = get_default_rendering_file_content()
+            assert 'function custom_polar_render_item(params, api)' in content
+            assert 'return "test"' in content
+            assert '"renderItem": custom_polar_render_item' in content
+            os.unlink('render.html')
+    else:
+        with assert_raises(exceptions.JavascriptNotSupported):
+            polar.add("", data, symbol_size=0, symbol='circle',
+                      start_angle=-25,
+                      area_color="#f3c5b3", type='custom',
+                      render_item=custom_polar_render_item,
+                      area_opacity=0.5, is_angleaxis_show=False)
+    javascript.clear()
 
 
 def test_json_encoder():

--- a/test/test_javascript.py
+++ b/test/test_javascript.py
@@ -1,4 +1,5 @@
 import os
+import sys
 
 from nose.tools import assert_raises
 
@@ -8,6 +9,9 @@ import pyecharts.exceptions as exceptions
 import pyecharts.javascript as javascript
 
 from test.utils import get_default_rendering_file_content
+
+
+WINDOWS = sys.platform == 'win32'
 
 
 def label_formatter(params):
@@ -27,6 +31,10 @@ def test_label_formatter():
         assert 'params.name + \"abc\"' in content
         assert '"formatter": label_formatter' in content
         os.unlink('render.html')
+    elif WINDOWS:
+        with assert_raises(exceptions.ExtensionMissing):
+            bar.render()
+        javascript.clear()
     else:
         with assert_raises(exceptions.JavascriptNotSupported):
             bar.render()
@@ -50,6 +58,10 @@ def test_yaxis_formatter():
         assert 'value + index' in content
         assert '"formatter": yaxis_formatter' in content
         os.unlink('render.html')
+    elif WINDOWS:
+        with assert_raises(exceptions.ExtensionMissing):
+            bar.render()
+        javascript.clear()
     else:
         with assert_raises(exceptions.JavascriptNotSupported):
             bar.render()
@@ -73,6 +85,10 @@ def test_xaxis_formatter():
         assert 'value + index' in content
         assert '"formatter": xaxis_formatter' in content
         os.unlink('render.html')
+    elif WINDOWS:
+        with assert_raises(exceptions.ExtensionMissing):
+            bar.render()
+        javascript.clear()
     else:
         with assert_raises(exceptions.JavascriptNotSupported):
             bar.render()
@@ -96,6 +112,10 @@ def test_tooltip_formatter():
         assert 'params.name + \"abc\"' in content
         assert '"formatter": tooltip_formatter' in content
         os.unlink('render.html')
+    elif WINDOWS:
+        with assert_raises(exceptions.ExtensionMissing):
+            bar.render()
+        javascript.clear()
     else:
         with assert_raises(exceptions.JavascriptNotSupported):
             bar.render()

--- a/test/test_javascript.py
+++ b/test/test_javascript.py
@@ -5,6 +5,7 @@ from nose.tools import assert_raises
 from pyecharts import Bar
 from pyecharts.constants import PY35_ABOVE
 import pyecharts.exceptions as exceptions
+import pyecharts.javascript as javascript
 
 from test.utils import get_default_rendering_file_content
 
@@ -29,6 +30,7 @@ def test_label_formatter():
     else:
         with assert_raises(exceptions.JavascriptNotSupported):
             bar.render()
+        javascript.clear()
 
 
 def yaxis_formatter(value, index):
@@ -51,7 +53,7 @@ def test_yaxis_formatter():
     else:
         with assert_raises(exceptions.JavascriptNotSupported):
             bar.render()
-
+        javascript.clear()
 
 def xaxis_formatter(value, index):
     return value + index
@@ -73,6 +75,7 @@ def test_xaxis_formatter():
     else:
         with assert_raises(exceptions.JavascriptNotSupported):
             bar.render()
+        javascript.clear()
 
 
 def tooltip_formatter(params):
@@ -95,3 +98,4 @@ def test_tooltip_formatter():
     else:
         with assert_raises(exceptions.JavascriptNotSupported):
             bar.render()
+        javascript.clear()

--- a/test/test_javascript.py
+++ b/test/test_javascript.py
@@ -1,7 +1,10 @@
 import os
 import sys
+import json
+from datetime import date
+import numpy as np
 
-from nose.tools import assert_raises
+from nose.tools import assert_raises, eq_
 
 from pyecharts import Bar
 from pyecharts.constants import PY35_ABOVE
@@ -23,20 +26,18 @@ def generic_formatter_t_est(**keywords):
     v1 = [2.0, 4.9]
     bar = Bar("Bar chart", "precipitation and evaporation one year")
     if PY35_ABOVE:
+        bar.add("precipitation", attr, v1, mark_line=["average"],
+                mark_point=["max", "min"],
+                **keywords)
         if WINDOWS:
             with assert_raises(exceptions.ExtensionMissing):
-                bar.add("precipitation", attr, v1, mark_line=["average"],
-                        mark_point=["max", "min"],
-                        **keywords)
+                bar.render()
         else:
-            bar.add("precipitation", attr, v1, mark_line=["average"],
-                    mark_point=["max", "min"], **keywords)
             bar.render()
     else:
         with assert_raises(exceptions.JavascriptNotSupported):
             bar.add("precipitation", attr, v1, mark_line=["average"],
                     mark_point=["max", "min"], **keywords)
-
     javascript.clear()
 
 
@@ -90,3 +91,17 @@ def test_tooltip_formatter():
         assert 'params.name + \"abc\"' in content
         assert '"formatter": tooltip_formatter' in content
         os.unlink('render.html')
+
+
+def test_json_encoder():
+    """
+    Test json encoder.
+    :return:
+    """
+    data = date(2017, 1, 1)
+    eq_(json.dumps({'date': '2017-01-01', 'a': '1'}, indent=0),
+        javascript.translate_options({'date': data, 'a': '1'}))
+
+    data2 = {'np_list': np.array(['a', 'b', 'c'])}
+    data2_e = {'np_list': ['a', 'b', 'c']}
+    eq_(json.dumps(data2_e, indent=0), javascript.translate_options(data2))

--- a/test/test_javascript.py
+++ b/test/test_javascript.py
@@ -89,9 +89,6 @@ def test_xaxis_formatter():
             assert 'value + index' in content
             assert '"formatter": xaxis_formatter' in content
             os.unlink('render.html')
-    elif WINDOWS:
-        with assert_raises(exceptions.ExtensionMissing):
-            bar.render()
     else:
         with assert_raises(exceptions.JavascriptNotSupported):
             bar.render()
@@ -119,9 +116,6 @@ def test_tooltip_formatter():
             assert 'params.name + \"abc\"' in content
             assert '"formatter": tooltip_formatter' in content
             os.unlink('render.html')
-    elif WINDOWS:
-        with assert_raises(exceptions.ExtensionMissing):
-            bar.render()
     else:
         with assert_raises(exceptions.JavascriptNotSupported):
             bar.render()

--- a/test/test_javascript.py
+++ b/test/test_javascript.py
@@ -18,27 +18,36 @@ def label_formatter(params):
     return params.name + 'abc'
 
 
-def test_label_formatter():
+def generic_formatter_t_est(**keywords):
     attr = ["Jan", "Feb"]
     v1 = [2.0, 4.9]
     bar = Bar("Bar chart", "precipitation and evaporation one year")
-    bar.add("precipitation", attr, v1, mark_line=["average"],
-            mark_point=["max", "min"], label_formatter=label_formatter)
     if PY35_ABOVE:
         if WINDOWS:
             with assert_raises(exceptions.ExtensionMissing):
-                bar.render()
+                bar.add("precipitation", attr, v1, mark_line=["average"],
+                        mark_point=["max", "min"],
+                        **keywords)
         else:
+            bar.add("precipitation", attr, v1, mark_line=["average"],
+                    mark_point=["max", "min"], **keywords)
             bar.render()
-            content = get_default_rendering_file_content()
-            assert 'function label_formatter(params)' in content
-            assert 'params.name + \"abc\"' in content
-            assert '"formatter": label_formatter' in content
-            os.unlink('render.html')
     else:
         with assert_raises(exceptions.JavascriptNotSupported):
-            bar.render()
+            bar.add("precipitation", attr, v1, mark_line=["average"],
+                    mark_point=["max", "min"], **keywords)
+
     javascript.clear()
+
+
+def test_label_formatter():
+    generic_formatter_t_est(label_formatter=label_formatter)
+    if PY35_ABOVE and not WINDOWS:
+        content = get_default_rendering_file_content()
+        assert 'function label_formatter(params)' in content
+        assert 'params.name + \"abc\"' in content
+        assert '"formatter": label_formatter' in content
+        os.unlink('render.html')
 
 
 def yaxis_formatter(value, index):
@@ -46,26 +55,13 @@ def yaxis_formatter(value, index):
 
 
 def test_yaxis_formatter():
-    attr = ["Jan", "Feb"]
-    v1 = [2.0, 4.9]
-    bar = Bar("Bar chart", "precipitation and evaporation one year")
-    bar.add("precipitation", attr, v1, mark_line=["average"],
-            mark_point=["max", "min"], yaxis_formatter=yaxis_formatter)
-    if PY35_ABOVE:
-        if WINDOWS:
-            with assert_raises(exceptions.ExtensionMissing):
-                bar.render()
-        else:
-            bar.render()
-            content = get_default_rendering_file_content()
-            assert 'function yaxis_formatter(value, index)' in content
-            assert 'value + index' in content
-            assert '"formatter": yaxis_formatter' in content
-            os.unlink('render.html')
-    else:
-        with assert_raises(exceptions.JavascriptNotSupported):
-            bar.render()
-    javascript.clear()
+    generic_formatter_t_est(yaxis_formatter=yaxis_formatter)
+    if PY35_ABOVE and not WINDOWS:
+        content = get_default_rendering_file_content()
+        assert 'function yaxis_formatter(value, index)' in content
+        assert 'value + index' in content
+        assert '"formatter": yaxis_formatter' in content
+        os.unlink('render.html')
 
 
 def xaxis_formatter(value, index):
@@ -73,26 +69,13 @@ def xaxis_formatter(value, index):
 
 
 def test_xaxis_formatter():
-    attr = ["Jan", "Feb"]
-    v1 = [2.0, 4.9]
-    bar = Bar("Bar chart", "precipitation and evaporation one year")
-    bar.add("precipitation", attr, v1, mark_line=["average"],
-            mark_point=["max", "min"], xaxis_formatter=xaxis_formatter)
-    if PY35_ABOVE:
-        if WINDOWS:
-            with assert_raises(exceptions.ExtensionMissing):
-                bar.render()
-        else:
-            bar.render()
-            content = get_default_rendering_file_content()
-            assert 'function xaxis_formatter(value, index)' in content
-            assert 'value + index' in content
-            assert '"formatter": xaxis_formatter' in content
-            os.unlink('render.html')
-    else:
-        with assert_raises(exceptions.JavascriptNotSupported):
-            bar.render()
-    javascript.clear()
+    generic_formatter_t_est(xaxis_formatter=xaxis_formatter)
+    if PY35_ABOVE and not WINDOWS:
+        content = get_default_rendering_file_content()
+        assert 'function xaxis_formatter(value, index)' in content
+        assert 'value + index' in content
+        assert '"formatter": xaxis_formatter' in content
+        os.unlink('render.html')
 
 
 def tooltip_formatter(params):
@@ -100,23 +83,10 @@ def tooltip_formatter(params):
 
 
 def test_tooltip_formatter():
-    attr = ["Jan", "Feb"]
-    v1 = [2.0, 4.9]
-    bar = Bar("Bar chart", "precipitation and evaporation one year")
-    bar.add("precipitation", attr, v1, mark_line=["average"],
-            mark_point=["max", "min"], tooltip_formatter=tooltip_formatter)
-    if PY35_ABOVE:
-        if WINDOWS:
-            with assert_raises(exceptions.ExtensionMissing):
-                bar.render()
-        else:
-            bar.render()
-            content = get_default_rendering_file_content()
-            assert 'function tooltip_formatter(params)' in content
-            assert 'params.name + \"abc\"' in content
-            assert '"formatter": tooltip_formatter' in content
-            os.unlink('render.html')
-    else:
-        with assert_raises(exceptions.JavascriptNotSupported):
-            bar.render()
-    javascript.clear()
+    generic_formatter_t_est(tooltip_formatter=tooltip_formatter)
+    if PY35_ABOVE and not WINDOWS:
+        content = get_default_rendering_file_content()
+        assert 'function tooltip_formatter(params)' in content
+        assert 'params.name + \"abc\"' in content
+        assert '"formatter": tooltip_formatter' in content
+        os.unlink('render.html')

--- a/test/test_javascript.py
+++ b/test/test_javascript.py
@@ -9,8 +9,8 @@ import pyecharts.exceptions as exceptions
 from test.utils import get_default_rendering_file_content
 
 
-def label_formatter(obj):
-    return obj.name + 'abc'
+def label_formatter(params):
+    return params.name + 'abc'
 
 
 def test_label_formatter():
@@ -22,8 +22,8 @@ def test_label_formatter():
     if PY35_ABOVE:
         bar.render()
         content = get_default_rendering_file_content()
-        assert 'function label_formatter(obj)' in content
-        assert 'obj.name + \"abc\"' in content
+        assert 'function label_formatter(params)' in content
+        assert 'params.name + \"abc\"' in content
         assert '"formatter": label_formatter' in content
         os.unlink('render.html')
     else:
@@ -31,8 +31,8 @@ def test_label_formatter():
             bar.render()
 
 
-def yaxis_formatter(obj):
-    return obj.name + 'abc'
+def yaxis_formatter(value, index):
+    return value + index
 
 
 def test_yaxis_formatter():
@@ -44,8 +44,8 @@ def test_yaxis_formatter():
     if PY35_ABOVE:
         bar.render()
         content = get_default_rendering_file_content()
-        assert 'function yaxis_formatter(obj)' in content
-        assert 'obj.name + \"abc\"' in content
+        assert 'function yaxis_formatter(value, index)' in content
+        assert 'value + index' in content
         assert '"formatter": yaxis_formatter' in content
         os.unlink('render.html')
     else:
@@ -53,8 +53,8 @@ def test_yaxis_formatter():
             bar.render()
 
 
-def xaxis_formatter(obj):
-    return obj.name + 'abc'
+def xaxis_formatter(value, index):
+    return value + index
 
 
 def test_xaxis_formatter():
@@ -66,8 +66,8 @@ def test_xaxis_formatter():
     if PY35_ABOVE:
         bar.render()
         content = get_default_rendering_file_content()
-        assert 'function xaxis_formatter(obj)' in content
-        assert 'obj.name + \"abc\"' in content
+        assert 'function xaxis_formatter(value, index)' in content
+        assert 'value + index' in content
         assert '"formatter": xaxis_formatter' in content
         os.unlink('render.html')
     else:
@@ -75,8 +75,8 @@ def test_xaxis_formatter():
             bar.render()
 
 
-def tooltip_formatter(obj):
-    return obj.name + 'abc'
+def tooltip_formatter(params):
+    return params.name + 'abc'
 
 
 def test_tooltip_formatter():
@@ -88,8 +88,8 @@ def test_tooltip_formatter():
     if PY35_ABOVE:
         bar.render()
         content = get_default_rendering_file_content()
-        assert 'function tooltip_formatter(obj)' in content
-        assert 'obj.name + \"abc\"' in content
+        assert 'function tooltip_formatter(params)' in content
+        assert 'params.name + \"abc\"' in content
         assert '"formatter": tooltip_formatter' in content
         os.unlink('render.html')
     else:

--- a/test/test_javascript.py
+++ b/test/test_javascript.py
@@ -1,0 +1,97 @@
+import os
+
+from nose.tools import assert_raises
+
+from pyecharts import Bar
+from pyecharts.constants import PY35_ABOVE
+import pyecharts.exceptions as exceptions
+
+from test.utils import get_default_rendering_file_content
+
+
+def label_formatter(obj):
+    return obj.name + 'abc'
+
+
+def test_label_formatter():
+    attr = ["Jan", "Feb"]
+    v1 = [2.0, 4.9]
+    bar = Bar("Bar chart", "precipitation and evaporation one year")
+    bar.add("precipitation", attr, v1, mark_line=["average"],
+            mark_point=["max", "min"], label_formatter=label_formatter)
+    if PY35_ABOVE:
+        bar.render()
+        content = get_default_rendering_file_content()
+        assert 'function label_formatter(obj)' in content
+        assert 'obj.name + \"abc\"' in content
+        assert '"formatter": label_formatter' in content
+        os.unlink('render.html')
+    else:
+        with assert_raises(exceptions.JavascriptNotSupported):
+            bar.render()
+
+
+def yaxis_formatter(obj):
+    return obj.name + 'abc'
+
+
+def test_yaxis_formatter():
+    attr = ["Jan", "Feb"]
+    v1 = [2.0, 4.9]
+    bar = Bar("Bar chart", "precipitation and evaporation one year")
+    bar.add("precipitation", attr, v1, mark_line=["average"],
+            mark_point=["max", "min"], yaxis_formatter=yaxis_formatter)
+    if PY35_ABOVE:
+        bar.render()
+        content = get_default_rendering_file_content()
+        assert 'function yaxis_formatter(obj)' in content
+        assert 'obj.name + \"abc\"' in content
+        assert '"formatter": yaxis_formatter' in content
+        os.unlink('render.html')
+    else:
+        with assert_raises(exceptions.JavascriptNotSupported):
+            bar.render()
+
+
+def xaxis_formatter(obj):
+    return obj.name + 'abc'
+
+
+def test_xaxis_formatter():
+    attr = ["Jan", "Feb"]
+    v1 = [2.0, 4.9]
+    bar = Bar("Bar chart", "precipitation and evaporation one year")
+    bar.add("precipitation", attr, v1, mark_line=["average"],
+            mark_point=["max", "min"], xaxis_formatter=xaxis_formatter)
+    if PY35_ABOVE:
+        bar.render()
+        content = get_default_rendering_file_content()
+        assert 'function xaxis_formatter(obj)' in content
+        assert 'obj.name + \"abc\"' in content
+        assert '"formatter": xaxis_formatter' in content
+        os.unlink('render.html')
+    else:
+        with assert_raises(exceptions.JavascriptNotSupported):
+            bar.render()
+
+
+def tooltip_formatter(obj):
+    return obj.name + 'abc'
+
+
+def test_tooltip_formatter():
+    attr = ["Jan", "Feb"]
+    v1 = [2.0, 4.9]
+    bar = Bar("Bar chart", "precipitation and evaporation one year")
+    bar.add("precipitation", attr, v1, mark_line=["average"],
+            mark_point=["max", "min"], tooltip_formatter=tooltip_formatter)
+    if PY35_ABOVE:
+        bar.render()
+        content = get_default_rendering_file_content()
+        assert 'function tooltip_formatter(obj)' in content
+        assert 'obj.name + \"abc\"' in content
+        assert '"formatter": tooltip_formatter' in content
+        os.unlink('render.html')
+    else:
+        with assert_raises(exceptions.JavascriptNotSupported):
+            bar.render()

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,18 +1,14 @@
 # coding=utf-8
 from __future__ import unicode_literals
 
-import codecs
-import json
 import os
-from datetime import date
+import codecs
 
-import numpy as np
 from nose.tools import eq_
 
 from pyecharts.utils import (
     write_utf8_html_file,
     get_resource_dir,
-    json_dumps,
     merge_js_dependencies
 )
 
@@ -30,20 +26,6 @@ def test_write_utf8_html_file():
     with codecs.open(file_name, 'r', 'utf-8') as f:
         actual_content = f.read()
         eq_(content, actual_content)
-
-
-def test_json_encoder():
-    """
-    Test json encoder.
-    :return:
-    """
-    data = date(2017, 1, 1)
-    eq_(json.dumps({'date': '2017-01-01', 'a': '1'}, indent=0),
-        json_dumps({'date': data, 'a': '1'}))
-
-    data2 = {'np_list': np.array(['a', 'b', 'c'])}
-    data2_e = {'np_list': ['a', 'b', 'c']}
-    eq_(json.dumps(data2_e, indent=0), json_dumps(data2))
 
 
 class MockChart(object):


### PR DESCRIPTION
1. 允许导入 python function 到 pyecharts 的图例
2. 先期允许 label_formatter, tooltip_formatter, xaxis_formatter 和 yaxis_formatter 传入 python function. 

长远设想是只要 echarts 允许的 js function 的设置，pyecharts 也就允许 python function. Like for like.

同时可以解决以下切实的问题：

https://github.com/pyecharts/pyecharts/issues/348
https://github.com/pyecharts/pyecharts/issues/461

<img width="1174" alt="screen shot 2018-03-31 at 22 59 56" src="https://user-images.githubusercontent.com/4280312/38167928-42fb12ea-3537-11e8-92dc-e5233131188d.png">
