### PR TITLE
Update: ES 图 X 轴 splitline 默认显示

### DIFF
--- a/docs/zh-cn/themes.md
+++ b/docs/zh-cn/themes.md
@@ -117,10 +117,9 @@ bar = Bar()
 
 ![purple-passion](https://user-images.githubusercontent.com/19553554/43997624-56ed56e2-9e13-11e8-95be-8815e1bdf0e5.png)
 
-# romantic
+#### romantic
 
 ![romantic](https://user-images.githubusercontent.com/19553554/44029175-eef6f170-9f2e-11e8-82cb-b60a39b28762.png)
-
 
 
 ## 使用自己构建的主题

--- a/pyecharts/charts/effectscatter.py
+++ b/pyecharts/charts/effectscatter.py
@@ -34,6 +34,8 @@ class EffectScatter(Scatter):
         chart = self._get_all_options(**kwargs)
 
         xaxis, yaxis = chart["xy_axis"]
+        # show split line, because by default split line is hidden for xaxis
+        xaxis[0]["splitLine"]["show"] = True
         self._option.update(xAxis=xaxis, yAxis=yaxis)
         self._option.get("legend")[0].get("data").append(name)
 

--- a/test/test_effectscatter.py
+++ b/test/test_effectscatter.py
@@ -70,3 +70,9 @@ def test_effectscatter_multiple_symbol_type():
         symbol="triangle",
     )
     es.render()
+
+
+def test_effectscatter_splitline():
+    es = EffectScatter("动态散点图各种图形示例")
+    es.add("", [10], [10],)
+    assert es.options["xAxis"][0]["splitLine"]["show"] == True


### PR DESCRIPTION
本次 PR 内容，修复 es 图 x 轴 splitiine 默认不显示的问题