### PR TITLE
:recycle: Rename chart build methods

### DIFF
--- a/docs/zh-cn/changelog.md
+++ b/docs/zh-cn/changelog.md
@@ -3,6 +3,7 @@
 * ### version 0.5.9（dev）
     
     #### Added
+    * [pr#690](https://github.com/pyecharts/pyecharts/pull/690) Radar 新增 `set_radar_component` 方法，废弃 `config` 方法；Parallel 图新增 `set_schema` 方法，废弃 `confg` 方法
     * [pr#685](https://github.com/pyecharts/pyecharts/pull/685) 图表方法(`use_theme`/`config`/`add`)支持链式调用
     * [issue#687](https://github.com/pyecharts/pyecharts/issues/687) 新增 `add_coordinate_json` 方法用于支持导入 Geo/Geolines 坐标数据
 

--- a/docs/zh-cn/charts.md
+++ b/docs/zh-cn/charts.md
@@ -1878,10 +1878,14 @@ add(name, data, **kwargs)
 * data -> [list], 包含列表的列表  
     数据项。数据中，每一行是一个『数据项』，每一列属于一个『维度』
 
-Parallel.config() 方法签名
+Parallel.set_schema() / Parallel.config() 方法签名
 ```python
+set_schema(schema=None, c_schema=None)
 config(schema=None, c_schema=None)
 ```
+
+> 从 v0.5.9 开始，原有 `config` 方法被废弃，推荐使用 set_schema 方法。
+
 * schema  
     默认平行坐标系的坐标轴信息，如 ["dim_name1", "dim_name2", "dim_name3"]。
 * c_schema  
@@ -2381,13 +2385,22 @@ add(name, value,
 * item_color -> str  
     指定单图例颜色
 
-Radar.config() 方法签名
+Radar.set_radar_component() / Radar.config() 方法签名
 ```python
+
+set_radar_component(schema=None,
+    c_schema=None,
+    shape="",
+    rader_text_color="#000", **kwargs):
+	
 config(schema=None,
     c_schema=None,
     shape="",
     rader_text_color="#000", **kwargs):
 ```
+
+> 从 v0.5.9 开始，原有的 `config` 被废弃，推荐使用 `set_radar_component` 方法。
+
 * schema -> list  
     默认雷达图的指示器，用来指定雷达图中的多个维度，会对数据处理成 {name:xx, value:xx} 的字典
 * c_schema -> dict  

--- a/pyecharts/charts/parallel.py
+++ b/pyecharts/charts/parallel.py
@@ -1,5 +1,7 @@
 # coding=utf-8
 
+import warnings
+
 from pyecharts.chart import Chart
 
 
@@ -17,7 +19,7 @@ class Parallel(Chart):
         self.__add(*args, **kwargs)
         return self
 
-    def config(self, schema=None, c_schema=None):
+    def set_schema(self, schema=None, c_schema=None):
         """
 
         :param schema:
@@ -40,6 +42,15 @@ class Parallel(Chart):
         if c_schema:
             self._option.update(parallelAxis=c_schema)
         return self
+
+    def config(self, schema=None, c_schema=None):
+        """The old alias name for set_schema.
+        """
+        deprecated_tpl = "The {} is deprecated, please use {} instead!"
+        warnings.warn(
+            deprecated_tpl.format("config", "set_schema"), DeprecationWarning
+        )
+        return self.set_schema(schema=schema, c_schema=c_schema)
 
     def __add(self, name, data, **kwargs):
         """

--- a/pyecharts/charts/radar.py
+++ b/pyecharts/charts/radar.py
@@ -14,7 +14,7 @@ class Radar(Chart):
     def __init__(self, title="", subtitle="", **kwargs):
         super(Radar, self).__init__(title, subtitle, **kwargs)
 
-    def set_schema(
+    def set_radar_component(
         self,
         schema=None,
         c_schema=None,
@@ -81,7 +81,7 @@ class Radar(Chart):
         warnings.warn(
             deprecated_tpl.format("config", "set_schema"), DeprecationWarning
         )
-        return self.set_schema(
+        return self.set_radar_component(
             schema=schema,
             c_schema=c_schema,
             shape=shape,

--- a/pyecharts/charts/radar.py
+++ b/pyecharts/charts/radar.py
@@ -1,4 +1,5 @@
 # coding=utf-8
+import warnings
 
 from pyecharts.chart import Chart
 
@@ -13,7 +14,7 @@ class Radar(Chart):
     def __init__(self, title="", subtitle="", **kwargs):
         super(Radar, self).__init__(title, subtitle, **kwargs)
 
-    def config(
+    def set_schema(
         self,
         schema=None,
         c_schema=None,
@@ -64,6 +65,30 @@ class Radar(Chart):
             }
         )
         return self
+
+    def config(
+        self,
+        schema=None,
+        c_schema=None,
+        shape="",
+        radar_text_color="#333",
+        radar_text_size=12,
+        **kwargs
+    ):
+        """The old alias for set_schema.
+        """
+        deprecated_tpl = "The {} is deprecated, please use {} instead!"
+        warnings.warn(
+            deprecated_tpl.format("config", "set_schema"), DeprecationWarning
+        )
+        return self.set_schema(
+            schema=schema,
+            c_schema=c_schema,
+            shape=shape,
+            radar_text_color=radar_text_color,
+            radar_text_size=radar_text_size,
+            **kwargs
+        )
 
     def add(self, *args, **kwargs):
         self.__add(*args, **kwargs)

--- a/test/test_parallel.py
+++ b/test/test_parallel.py
@@ -21,7 +21,7 @@ def test_parallel_default():
         [11, 117, 81, 124, 1.03, 45],
     ]
     parallel = Parallel("平行坐标系-默认指示器")
-    parallel.config(schema)
+    parallel.set_schema(schema)
     parallel.add("parallel", data, is_random=True)
     parallel.render()
 
@@ -59,7 +59,7 @@ def test_parallel_user_define():
         [14, 116, 87, 131, 1.47, 84, 40, "轻度污染"],
     ]
     parallel = Parallel("平行坐标系-用户自定义指示器")
-    parallel.config(c_schema=c_schema)
+    parallel.set_schema(c_schema=c_schema)
     parallel.add("parallel", data)
     parallel.render()
 

--- a/test/test_radar.py
+++ b/test/test_radar.py
@@ -17,7 +17,7 @@ def test_radar_default_schema():
     v1 = [[4300, 10000, 28000, 35000, 50000, 19000]]
     v2 = [[5000, 14000, 28000, 31000, 42000, 21000]]
     radar = Radar("雷达图示例")
-    radar.config(schema)
+    radar.set_schema(schema)
     radar.add("预算分配", v1, is_splitline=True, is_axisline_show=True)
     radar.add(
         "实际开销",
@@ -109,7 +109,7 @@ c_schema = [
 
 def test_radar_user_define_schema_single():
     radar = Radar("雷达图示例")
-    radar.config(c_schema=c_schema, shape="circle")
+    radar.set_schema(c_schema=c_schema, shape="circle")
     radar.add("北京", value_bj, item_color="#f9713c", symbol=None)
     radar.add(
         "上海",

--- a/test/test_radar.py
+++ b/test/test_radar.py
@@ -17,7 +17,7 @@ def test_radar_default_schema():
     v1 = [[4300, 10000, 28000, 35000, 50000, 19000]]
     v2 = [[5000, 14000, 28000, 31000, 42000, 21000]]
     radar = Radar("雷达图示例")
-    radar.set_schema(schema)
+    radar.set_radar_component(schema)
     radar.add("预算分配", v1, is_splitline=True, is_axisline_show=True)
     radar.add(
         "实际开销",
@@ -109,7 +109,7 @@ c_schema = [
 
 def test_radar_user_define_schema_single():
     radar = Radar("雷达图示例")
-    radar.set_schema(c_schema=c_schema, shape="circle")
+    radar.set_radar_component(c_schema=c_schema, shape="circle")
     radar.add("北京", value_bj, item_color="#f9713c", symbol=None)
     radar.add(
         "上海",


### PR DESCRIPTION
本次 PR 内容，

As a subsequent of #685 ,this PR renames some methods to follow a rule for *Chart Build Method*.

The name should a **verb-noun** format as

```
<op>_<feature>
```
Note:
- `<op>`: `add` / `use` / `set`
- `<feature>`: `data` / `theme` / `schema` / `style`

This is a good example:

- use_theme
- set_schema
- use_style
- add_values (add)

`config` is a general name and should to renamed to match its feature.


