### PR TITLE
Fix #749: Display heatmap y-axis label correctly

### DIFF
--- a/pyecharts/charts/heatmap.py
+++ b/pyecharts/charts/heatmap.py
@@ -44,6 +44,8 @@ class HeatMap(Chart):
         else:
             name, x_axis, y_axis, data = args
 
+        if "yaxis_formatter" not in kwargs:
+            kwargs["yaxis_formatter"] = None
         chart = self._get_all_options(**kwargs)
         self._option.get("legend")[0].get("data").append(name)
 

--- a/pyecharts/echarts/axis.py
+++ b/pyecharts/echarts/axis.py
@@ -29,7 +29,10 @@ class XAxisLabel(AxisLabel):
 
 class YAxisLabel(AxisLabel):
     def __init__(self, formatter=None, **kwargs):
-        if formatter is not None and not isinstance(formatter, types.FunctionType):
+        if (
+            formatter is not None and
+            not isinstance(formatter, types.FunctionType)
+        ):
             formatter = "{value} " + formatter
         super(YAxisLabel, self).__init__(formatter=formatter, **kwargs)
 

--- a/pyecharts/echarts/axis.py
+++ b/pyecharts/echarts/axis.py
@@ -29,7 +29,7 @@ class XAxisLabel(AxisLabel):
 
 class YAxisLabel(AxisLabel):
     def __init__(self, formatter=None, **kwargs):
-        if not isinstance(formatter, types.FunctionType):
+        if formatter is not None and not isinstance(formatter, types.FunctionType):
             formatter = "{value} " + formatter
         super(YAxisLabel, self).__init__(formatter=formatter, **kwargs)
 

--- a/test/test_axis.py
+++ b/test/test_axis.py
@@ -17,7 +17,7 @@ def test_yaxis_wo_formatter():
     )
     assert label.__json__() == {
         'interval': 'auto',
-        'rotate': 0, 
+        'rotate': 0,
         'margin': 8,
         'textStyle': {'fontSize': 12, 'color': '#000'},
     }
@@ -34,7 +34,7 @@ def test_yaxis_none_formatter():
     )
     assert label.__json__() == {
         'interval': 'auto',
-        'rotate': 0, 
+        'rotate': 0,
         'margin': 8,
         'textStyle': {'fontSize': 12, 'color': '#000'},
     }
@@ -51,7 +51,7 @@ def test_yaxis_str_formatter():
     )
     assert label.__json__() == {
         'interval': 'auto',
-        'rotate': 0, 
+        'rotate': 0,
         'margin': 8,
         'textStyle': {'fontSize': 12, 'color': '#000'},
         'formatter': '{value} ',
@@ -75,7 +75,7 @@ def test_yaxis_func_formatter():
     del json_obj['formatter']
     assert json_obj == {
         'interval': 'auto',
-        'rotate': 0, 
+        'rotate': 0,
         'margin': 8,
         'textStyle': {'fontSize': 12, 'color': '#000'},
     }

--- a/test/test_axis.py
+++ b/test/test_axis.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+# coding=utf-8
+from __future__ import unicode_literals
+
+import types
+
+from pyecharts.echarts import YAxisLabel
+
+
+def test_yaxis_wo_formatter():
+    label = YAxisLabel(
+        interval="auto",
+        rotate=0,
+        margin=8,
+        text_size=12,
+        text_color="#000",
+    )
+    assert label.__json__() == {
+        'interval': 'auto',
+        'rotate': 0, 
+        'margin': 8,
+        'textStyle': {'fontSize': 12, 'color': '#000'},
+    }
+
+
+def test_yaxis_none_formatter():
+    label = YAxisLabel(
+        interval="auto",
+        rotate=0,
+        margin=8,
+        text_size=12,
+        text_color="#000",
+        formatter=None,
+    )
+    assert label.__json__() == {
+        'interval': 'auto',
+        'rotate': 0, 
+        'margin': 8,
+        'textStyle': {'fontSize': 12, 'color': '#000'},
+    }
+
+
+def test_yaxis_str_formatter():
+    label = YAxisLabel(
+        interval="auto",
+        rotate=0,
+        margin=8,
+        text_size=12,
+        text_color="#000",
+        formatter="",
+    )
+    assert label.__json__() == {
+        'interval': 'auto',
+        'rotate': 0, 
+        'margin': 8,
+        'textStyle': {'fontSize': 12, 'color': '#000'},
+        'formatter': '{value} ',
+    }
+
+
+def test_yaxis_func_formatter():
+    def formatter(params):
+        return "test"
+
+    label = YAxisLabel(
+        interval="auto",
+        rotate=0,
+        margin=8,
+        text_size=12,
+        text_color="#000",
+        formatter=formatter,
+    )
+    json_obj = label.__json__()
+    assert isinstance(json_obj['formatter'], types.FunctionType)
+    del json_obj['formatter']
+    assert json_obj == {
+        'interval': 'auto',
+        'rotate': 0, 
+        'margin': 8,
+        'textStyle': {'fontSize': 12, 'color': '#000'},
+    }

--- a/test/test_heatmap.py
+++ b/test/test_heatmap.py
@@ -29,6 +29,43 @@ def test_heatmap_default():
     assert "Monday" in html_content
 
 
+def test_heatmap_display_yaxis_label():
+    data = [[i, j, random.randint(0, 50)] for i in range(24) for j in range(7)]
+    heatmap = HeatMap()
+    heatmap.add(
+        "热力图直角坐标系",
+        X_TIME,
+        Y_WEEK,
+        data,
+        is_visualmap=True,
+        is_label_show=False,
+        visual_text_color="#000",
+        visual_orient='horizontal',
+    )
+    html_content = heatmap._repr_html_()
+    assert r'"formatter": "{value} "' not in html_content
+    assert str(X_TIME) in html_content
+
+
+def test_heatmap_yaxis_formatter():
+    data = [[i, j, random.randint(0, 50)] for i in range(24) for j in range(7)]
+    heatmap = HeatMap()
+    heatmap.add(
+        "热力图直角坐标系",
+        X_TIME,
+        Y_WEEK,
+        data,
+        is_visualmap=True,
+        is_label_show=False,
+        visual_text_color="#000",
+        visual_orient='horizontal',
+        yaxis_formatter="",
+    )
+    html_content = heatmap._repr_html_()
+    assert r'"formatter": "{value} "' in html_content
+    assert str(X_TIME) in html_content
+
+
 def test_heatmap_calendar():
     import datetime
 

--- a/test/test_heatmap.py
+++ b/test/test_heatmap.py
@@ -44,7 +44,8 @@ def test_heatmap_display_yaxis_label():
     )
     html_content = heatmap._repr_html_()
     assert r'"formatter": "{value} "' not in html_content
-    assert str(X_TIME) in html_content
+    assert "Saturday" in html_content
+    assert "Monday" in html_content
 
 
 def test_heatmap_yaxis_formatter():
@@ -63,7 +64,8 @@ def test_heatmap_yaxis_formatter():
     )
     html_content = heatmap._repr_html_()
     assert r'"formatter": "{value} "' in html_content
-    assert str(X_TIME) in html_content
+    assert "Saturday" in html_content
+    assert "Monday" in html_content
 
 
 def test_heatmap_calendar():


### PR DESCRIPTION
I believe the PR will fix #749 and do no harm to other formats.

The following example shows before and after the modification (extracted from https://github.com/pyecharts/pyecharts-users-cases/blob/master/notebook-users-cases/notebook-user-cases.ipynb):

## Before the fix
![before](https://user-images.githubusercontent.com/15517661/48669357-59b3e500-eb46-11e8-90a7-a4ff28e7294c.png)

## After the fix
![after](https://user-images.githubusercontent.com/15517661/48669361-60daf300-eb46-11e8-867b-43ec9fcdca05.png)
