### PR TITLE
Fix: InitOpts 使用 js_host 参数无效的问题

### DIFF
--- a/pyecharts/charts/base.py
+++ b/pyecharts/charts/base.py
@@ -27,7 +27,7 @@ class Base:
         self.chart_id = init_opts.chart_id or uuid.uuid4().hex
 
         self.options: dict = {}
-        self.js_host: str = CurrentConfig.ONLINE_HOST
+        self.js_host: str = init_opts.js_host or CurrentConfig.ONLINE_HOST
         self.js_functions: utils.OrderedSet = utils.OrderedSet()
         self.js_dependencies: utils.OrderedSet = utils.OrderedSet("echarts")
 


### PR DESCRIPTION
本次 PR 内容，修复 InitOpts 使用 js_host 参数无效的问题

```python
#!/usr/bin/env python
# coding=utf-8
from __future__ import unicode_literals

from pyecharts.charts import Bar
from pyecharts.options import InitOpts


clothes_v1 = [5, 20, 36, 10, 75, 90]
clothes_v2 = [10, 25, 8, 60, 20, 80]


def test_bar():
    # 配置
    option = InitOpts(
        chart_id="test_chart_id",
        renderer="svg",
        js_host="https://cdn.bootcss.com/echarts/4.2.1/")
    # 画图
    (
        Bar(init_opts=option)
        .add_xaxis(["A", "B", "C"])
        .add_yaxis("bar0", [1, 2, 4])
        .add_yaxis("bar1", [2, 3, 6])
        .render()
    )


if __name__ == '__main__':
    test_bar()

```