### PR TITLE
Enable new feature in echarts-china-cities-js: 370 city contours

### DIFF
--- a/pyecharts/datasets/__init__.py
+++ b/pyecharts/datasets/__init__.py
@@ -25,7 +25,8 @@ def register_url(asset_url: str):
             file_name = contents["FILE_MAP"][pinyin]
             files[name] = [file_name, "js"]
 
-        EXTRA[contents["GITHUB_URL"] + "/"] = files
+        js_file_prefix = f'{contents["GITHUB_URL"]}/{contents["JS_FOLDER"]}/'
+        EXTRA[js_file_prefix] = files
 
 
 def register_files(asset_files: dict):

--- a/test/fixtures/registry.json
+++ b/test/fixtures/registry.json
@@ -1,0 +1,13 @@
+{
+    "JUPYTER_URL": "/nbextensions/echarts-china-cities-js",
+    "GITHUB_URL": "https://echarts-maps.github.io/echarts-china-cities-js",
+    "JUPYTER_ENTRY": "echarts-china-cities-js/index",
+    "JS_FOLDER": "js",
+    "GEOJSON_FOLDER": "geojson",
+    "PINYIN_MAP": {
+         "安庆": "an1_qing4"
+    },
+    "FILE_MAP": {
+        "an1_qing4": "shape-with-internal-borders/an1_hui1_an1_qing4"
+    }
+}

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -9,7 +9,9 @@ from pyecharts.datasets import EXTRA, register_url
 @patch("pyecharts.datasets.urllib.request.urlopen")
 def test_register_url(fake):
     current_path = os.path.dirname(__file__)
-    with open(os.path.join(current_path, "fixtures", "registry.json"), encoding="utf8") as f:
+    with open(
+        os.path.join(current_path, "fixtures", "registry.json"), encoding="utf8"
+    ) as f:
         fake.return_value = f
         register_url("fake_url")
         eq_(

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -1,17 +1,22 @@
 import os
-
-from pyecharts.datasets import register_url, EXTRA
 from unittest.mock import patch
+
 from nose.tools import eq_
 
+from pyecharts.datasets import EXTRA, register_url
 
-@patch('pyecharts.datasets.urllib.request.urlopen')
+
+@patch("pyecharts.datasets.urllib.request.urlopen")
 def test_register_url(fake):
     current_path = os.path.dirname(__file__)
-    with open(os.path.join(current_path, "fixtures", "registry.json")) as f:
+    with open(os.path.join(current_path, "fixtures", "registry.json"), encoding="utf8") as f:
         fake.return_value = f
-        register_url('fake_url')
-        eq_(EXTRA, {
-            'https://echarts-maps.github.io/echarts-china-cities-js/js/':
-            {'安庆': ['shape-with-internal-borders/an1_hui1_an1_qing4', 'js']}
-        })
+        register_url("fake_url")
+        eq_(
+            EXTRA,
+            {
+                "https://echarts-maps.github.io/echarts-china-cities-js/js/": {
+                    "安庆": ["shape-with-internal-borders/an1_hui1_an1_qing4", "js"]
+                }
+            },
+        )

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -1,0 +1,16 @@
+import os
+
+from pyecharts.datasets import register_url, EXTRA
+from unittest.mock import patch
+from nose.tools import eq_
+
+
+@patch('pyecharts.datasets.urllib.request.urlopen')
+def test_register_url(fake):
+    with open(os.path.join("test", "fixtures", "registry.json")) as f:
+        fake.return_value = f
+        register_url('fake_url')
+        eq_(EXTRA, {
+            'https://echarts-maps.github.io/echarts-china-cities-js/js/':
+            {'安庆': ['shape-with-internal-borders/an1_hui1_an1_qing4', 'js']}
+        })

--- a/test/test_datasets.py
+++ b/test/test_datasets.py
@@ -7,7 +7,8 @@ from nose.tools import eq_
 
 @patch('pyecharts.datasets.urllib.request.urlopen')
 def test_register_url(fake):
-    with open(os.path.join("test", "fixtures", "registry.json")) as f:
+    current_path = os.path.dirname(__file__)
+    with open(os.path.join(current_path, "fixtures", "registry.json")) as f:
         fake.return_value = f
         register_url('fake_url')
         eq_(EXTRA, {


### PR DESCRIPTION
我们现在已经有北京市区图：
<img width="816" alt="Screenshot 2019-05-13 at 18 39 16" src="https://user-images.githubusercontent.com/4280312/57642078-6c1b5280-75ae-11e9-84df-6d8e3fdeb87b.png">

但是，我们过去没有，但现在有了北京轮廓：

<img width="809" alt="Screenshot 2019-05-13 at 18 38 36" src="https://user-images.githubusercontent.com/4280312/57642038-5c037300-75ae-11e9-8fb3-796469154453.png">

这里是[其他的369个图](https://echarts-maps.github.io/echarts-china-cities-js/shape-only-preview.html)：
<img width="1040" alt="Screenshot 2019-05-10 at 09 11 01" src="https://user-images.githubusercontent.com/4280312/57642248-be5c7380-75ae-11e9-94b1-0a9b05310eed.png">

