### PR TITLE
Zoom in a region

### DIFF
--- a/pyecharts/charts/basic_charts/geo.py
+++ b/pyecharts/charts/basic_charts/geo.py
@@ -150,7 +150,7 @@ class Geo(GeoChartBase):
         maptype: str = "china",
         is_roam: bool = True,
         zoom: Optional[Numeric] = None,
-        center: Union[Sequence, None] = None,
+        center: Optional[Sequence] = None,
         label_opts: Union[opts.LabelOpts, dict, None] = None,
         itemstyle_opts: Union[opts.ItemStyleOpts, dict, None] = None,
         emphasis_itemstyle_opts: Union[opts.ItemStyleOpts, dict, None] = None,

--- a/pyecharts/charts/basic_charts/geo.py
+++ b/pyecharts/charts/basic_charts/geo.py
@@ -2,7 +2,7 @@ import json
 
 from ... import options as opts
 from ...charts.chart import Chart
-from ...commons.types import Numeric, Optional, Sequence, Union, List
+from ...commons.types import Numeric, Optional, Sequence, Union
 from ...datasets import COORDINATES
 from ...globals import ChartType
 
@@ -149,8 +149,8 @@ class Geo(GeoChartBase):
         self,
         maptype: str = "china",
         is_roam: bool = True,
-        zoom: Numeric = None,
-        center: Union[List, None] = None,
+        zoom: Optional[Numeric] = None,
+        center: Union[Sequence, None] = None,
         label_opts: Union[opts.LabelOpts, dict, None] = None,
         itemstyle_opts: Union[opts.ItemStyleOpts, dict, None] = None,
         emphasis_itemstyle_opts: Union[opts.ItemStyleOpts, dict, None] = None,

--- a/pyecharts/charts/basic_charts/geo.py
+++ b/pyecharts/charts/basic_charts/geo.py
@@ -2,7 +2,7 @@ import json
 
 from ... import options as opts
 from ...charts.chart import Chart
-from ...commons.types import Numeric, Optional, Sequence, Union
+from ...commons.types import Numeric, Optional, Sequence, Union, List
 from ...datasets import COORDINATES
 from ...globals import ChartType
 
@@ -149,15 +149,21 @@ class Geo(GeoChartBase):
         self,
         maptype: str = "china",
         is_roam: bool = True,
+        zoom: Numeric = None,
+        center: Union[List, None] = None,
         label_opts: Union[opts.LabelOpts, dict, None] = None,
         itemstyle_opts: Union[opts.ItemStyleOpts, dict, None] = None,
         emphasis_itemstyle_opts: Union[opts.ItemStyleOpts, dict, None] = None,
         emphasis_label_opts: Union[opts.LabelOpts, dict, None] = None,
     ):
         self.js_dependencies.add(maptype)
+        if center:
+            assert len(center) == 2
         self.options.update(
             geo={
                 "map": maptype,
+                "zoom": zoom,
+                "center": center,
                 "roam": is_roam,
                 "label": label_opts,
                 "itemStyle": itemstyle_opts,

--- a/test/test_geo.py
+++ b/test/test_geo.py
@@ -1,11 +1,15 @@
-from nose.tools import eq_
+from unittest.mock import patch
+
+from nose.tools import eq_, assert_in
 
 from example.commons import Faker
 from pyecharts import options as opts
 from pyecharts.charts import Geo
+from textwrap import dedent
 
 
-def test_geo_base():
+@patch("pyecharts.render.engine.write_utf8_html_file")
+def test_geo_base(fake_writer):
     c = (
         Geo()
         .add_schema(maptype="china")
@@ -14,5 +18,29 @@ def test_geo_base():
         .set_global_opts(visualmap_opts=opts.VisualMapOpts())
     )
     eq_(c.theme, "white")
+    c.render()
+    _, content = fake_writer.call_args[0]
+    assert_in("canvas", content)
+
+
+@patch("pyecharts.render.engine.write_utf8_html_file")
+def test_extra_geo_parameters(fake_writer):
+    c = (
+        Geo()
+        .add_schema(maptype="china", center=[39, 117.7], zoom=9)
+        .add("geo", [list(z) for z in zip(Faker.provinces, Faker.values())])
+        .set_series_opts(label_opts=opts.LabelOpts(is_show=False))
+        .set_global_opts(visualmap_opts=opts.VisualMapOpts())
+    )
+    eq_(c.theme, "white")
     eq_(c.renderer, "canvas")
     c.render()
+    _, content = fake_writer.call_args[0]
+    center_string = """
+        "center": [
+            39,
+            117.7
+        ],
+    """
+    assert_in(center_string, content)
+    assert_in('"zoom": 9', content)

--- a/test/test_geo.py
+++ b/test/test_geo.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from nose.tools import eq_, assert_in
+from nose.tools import assert_in, eq_
 
 from example.commons import Faker
 from pyecharts import options as opts

--- a/test/test_geo.py
+++ b/test/test_geo.py
@@ -5,7 +5,6 @@ from nose.tools import eq_, assert_in
 from example.commons import Faker
 from pyecharts import options as opts
 from pyecharts.charts import Geo
-from textwrap import dedent
 
 
 @patch("pyecharts.render.engine.write_utf8_html_file")


### PR DESCRIPTION
This PR introduces: `center` and `zoom` to geo's add_schema function.

```
   Geo()
        .add_schema(maptype="world", center=[6, 50.4], zoom=12)
        .add(
```

pyecharts user can choose a custom center on the map and zoom in:

<img width="821" alt="Screenshot 2019-06-05 at 07 48 31" src="https://user-images.githubusercontent.com/4280312/58935985-99e75780-8766-11e9-98db-d0338e93b37b.png">

Without this PR, it looks like the following:

<img width="771" alt="Screenshot 2019-06-05 at 07 48 58" src="https://user-images.githubusercontent.com/4280312/58936006-a8ce0a00-8766-11e9-9d26-85a07c8a0d5d.png">


