### PR TITLE
add emphasis to map

### DIFF
--- a/pyecharts/charts/basic_charts/map.py
+++ b/pyecharts/charts/basic_charts/map.py
@@ -30,6 +30,8 @@ class Map(Chart):
         label_opts: Union[opts.LabelOpts, dict] = opts.LabelOpts(),
         tooltip_opts: Union[opts.TooltipOpts, dict, None] = None,
         itemstyle_opts: Union[opts.ItemStyleOpts, dict, None] = None,
+        emphasis_label_opts: Union[opts.LabelOpts, dict] = None,
+        emphasis_itemstyle_opts: Union[opts.ItemStyleOpts, dict, None] = None,
     ):
         self.js_dependencies.add(maptype)
         data = [{"name": n, "value": v} for n, v in data_pair]
@@ -49,6 +51,10 @@ class Map(Chart):
                 "showLegendSymbol": is_map_symbol_show,
                 "tooltip": tooltip_opts,
                 "itemStyle": itemstyle_opts,
+                "emphasis": {
+                    "label": emphasis_label_opts,
+                    "itemStyle": emphasis_itemstyle_opts
+                }
             }
         )
         return self

--- a/test/test_map.py
+++ b/test/test_map.py
@@ -1,9 +1,11 @@
 from unittest.mock import patch
 
+import json
 from nose.tools import eq_
 
 from example.commons import Faker
 from pyecharts.charts import Map
+from pyecharts import options as opts
 
 
 @patch("pyecharts.render.engine.write_utf8_html_file")
@@ -15,3 +17,19 @@ def test_map_base(fake_writer):
     _, content = fake_writer.call_args[0]
     eq_(c.theme, "white")
     eq_(c.renderer, "canvas")
+
+
+def test_map_emphasis():
+    c = Map().add(
+        "商家A",
+        [list(z) for z in zip(Faker.provinces, Faker.values())],
+        "china",
+        emphasis_label_opts=opts.LabelOpts(is_show=False),
+        emphasis_itemstyle_opts=opts.ItemStyleOpts(border_color="white"),
+    )
+    options = json.loads(c.dump_options())
+    expected = {
+        "label": {"show": False, "position": "top", "margin": 8},
+        "itemStyle": {"borderColor": "white"},
+    }
+    eq_(expected, options["series"][0]["emphasis"])


### PR DESCRIPTION
It is required to suppress:

1. on focus, change broder color from white to black
2. on focus, do not show label but only tooltip

for the following geo presentation:

<img width="200" alt="Screenshot 2019-06-09 at 13 56 39" src="https://user-images.githubusercontent.com/4280312/59159234-743bb480-8abe-11e9-98ba-58a1a54e22e5.png">
