### PR TITLE
Fix: use 'ignore_nan' for dump_options

### DIFF
--- a/pyecharts/charts/base.py
+++ b/pyecharts/charts/base.py
@@ -1,5 +1,5 @@
 import datetime
-import json
+import simplejson as json
 import os
 import uuid
 
@@ -50,7 +50,7 @@ class Base:
 
     def dump_options(self) -> str:
         return utils.replace_placeholder(
-            json.dumps(self.get_options(), indent=4, default=default)
+            json.dumps(self.get_options(), indent=4, default=default, ignore_nan=True)
         )
 
     def render(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 jinja2>=2.8
 prettytable
+simplejson

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ __url__ = "https://github.com/pyecharts/pyecharts"
 __author_email__ = "chenjiandongx@qq.com"
 __license__ = "MIT"
 
-__requires__ = ["jinja2", "prettytable"]
+__requires__ = ["jinja2", "prettytable", "simplejson"]
 __extra_requires__ = {
     "selenium": ["snapshot-selenium"],
     "phantomjs": ["snapshot-phantomjs"],


### PR DESCRIPTION
`NaN` is not valid in standard JSON, and javascript cannot parse `NaN`. However, `json.dumps` in python allows NaN values. This pull request aims to fix this by using simplejson library which supports 'ignore_nan' option. This is very likely not the best solution anyway, so please feel free to use this PR or discard it.

这个问题是我在使用[Django前后端分离](https://pyecharts.org/#/zh-cn/web_django?id=step-2-%e7%bc%96%e5%86%99%e7%94%bb%e5%9b%be-html-%e4%bb%a3%e7%a0%81)的时候发现的，dump_options()生成的json有`NaN`，而javascript无法parse，导致报错。使用ignore_nan可以修复这个问题。

