### PR TITLE
Enable area color in map

### DIFF
--- a/pyecharts/_version.py
+++ b/pyecharts/_version.py
@@ -1,2 +1,2 @@
-__version__ = "1.3.0"
+__version__ = "1.3.1"
 __author__ = "chenjiandongx"

--- a/pyecharts/options/series_options.py
+++ b/pyecharts/options/series_options.py
@@ -25,6 +25,7 @@ class ItemStyleOpts(BasicOpts):
         border_color0: Optional[str] = None,
         border_width: Optional[Numeric] = None,
         opacity: Optional[Numeric] = None,
+        area_color: Optional[str] = None,
     ):
         self.opts: dict = {
             "color": color,
@@ -33,6 +34,7 @@ class ItemStyleOpts(BasicOpts):
             "borderColor0": border_color0,
             "borderWidth": border_width,
             "opacity": opacity,
+            "areaColor": area_color
         }
 
 

--- a/test/test_item_style_options.py
+++ b/test/test_item_style_options.py
@@ -1,0 +1,7 @@
+from pyecharts import options as opts
+from nose.tools import eq_
+
+
+def test_area_color_in_item_styles():
+    op = opts.ItemStyleOpts(area_color='red')
+    eq_(op.opts['areaColor'], 'red')

--- a/test/test_map.py
+++ b/test/test_map.py
@@ -25,11 +25,12 @@ def test_map_emphasis():
         [list(z) for z in zip(Faker.provinces, Faker.values())],
         "china",
         emphasis_label_opts=opts.LabelOpts(is_show=False),
-        emphasis_itemstyle_opts=opts.ItemStyleOpts(border_color="white"),
+        emphasis_itemstyle_opts=opts.ItemStyleOpts(border_color="white",
+                                                   area_color="red"),
     )
     options = json.loads(c.dump_options())
     expected = {
         "label": {"show": False, "position": "top", "margin": 8},
-        "itemStyle": {"borderColor": "white"},
+        "itemStyle": {"borderColor": "white", "areaColor": "red"},
     }
     eq_(expected, options["series"][0]["emphasis"])


### PR DESCRIPTION
delivers #1248

# before

<img width="865" alt="Screenshot 2019-07-15 at 09 34 56" src="https://user-images.githubusercontent.com/4280312/61204038-0e0d0780-a6e4-11e9-935e-1361b968a3da.png">

# code

m = (Map().add(
    maptype='world',
    series_name="World Population",
    data_pair=data[1:],
    is_map_symbol_show=False,
    itemstyle_opts = opts.ItemStyleOpts(area_color='red'),
    label_opts=opts.LabelOpts(is_show=False)
).set_global_opts(visualmap_opts=opts.VisualMapOpts(
        min_=low,
        max_=high,
        range_text=["max", "min"],
        is_calculable=True,
        range_color=["lightskyblue", "yellow", "orangered"],
    )
))
m.render_notebook()

# after

<img width="193" alt="Screenshot 2019-07-15 at 09 35 46" src="https://user-images.githubusercontent.com/4280312/61204043-16654280-a6e4-11e9-9331-69007fdeeac8.png">
