### PR TITLE
update gauge config

### DIFF
--- a/example/gauge_example.py
+++ b/example/gauge_example.py
@@ -49,12 +49,28 @@ def gauge_splitnum_label() -> Gauge:
                     color=[(0.3, "#67e0e3"), (0.7, "#37a2da"), (1, "#fd666d")], width=30
                 )
             ),
-            label_opts=opts.LabelOpts(formatter="{value}"),
+            detail_label_opts=opts.LabelOpts(formatter="{value}"),
         )
         .set_global_opts(
             title_opts=opts.TitleOpts(title="Gauge-分割段数-Label"),
             legend_opts=opts.LegendOpts(is_show=False),
         )
+    )
+    return c
+
+
+@C.funcs
+def gauge_label_title_setting() -> Gauge:
+    c = (
+        Gauge()
+        .add(
+            "",
+            [("完成率", 66.6)],
+            title_label_opts=opts.LabelOpts(
+                font_size=40, color="blue", font_family="Microsoft YaHei"
+            ),
+        )
+        .set_global_opts(title_opts=opts.TitleOpts(title="Gauge-改变轮盘内的字体"))
     )
     return c
 

--- a/pyecharts/charts/basic_charts/gauge.py
+++ b/pyecharts/charts/basic_charts/gauge.py
@@ -22,7 +22,8 @@ class Gauge(Chart):
         split_number: types.Numeric = 10,
         start_angle: types.Numeric = 225,
         end_angle: types.Numeric = -45,
-        label_opts: types.Label = opts.LabelOpts(formatter="{value}%"),
+        title_label_opts: types.Label = opts.LabelOpts(),
+        detail_label_opts: types.Label = opts.LabelOpts(formatter="{value}%"),
         tooltip_opts: types.Tooltip = None,
         axisline_opts: types.AxisLine = None,
         itemstyle_opts: types.ItemStyle = None,
@@ -32,7 +33,8 @@ class Gauge(Chart):
         self.options.get("series").append(
             {
                 "type": ChartType.GAUGE,
-                "detail": label_opts,
+                "title": title_label_opts,
+                "detail": detail_label_opts,
                 "name": series_name,
                 "min": min_,
                 "max": max_,

--- a/test/test_gauge.py
+++ b/test/test_gauge.py
@@ -27,8 +27,8 @@ def test_gauage_label_setting(fake_writer):
                 font_size=40, color="blue", font_family="Microsoft YaHei"
             ),
         )
-        .render()
     )
+    c.render()
     _, content = fake_writer.call_args[0]
     assert_in("title", content)
     assert_in("detail", content)

--- a/test/test_gauge.py
+++ b/test/test_gauge.py
@@ -1,8 +1,9 @@
 from unittest.mock import patch
 
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_in
 
 from pyecharts.charts import Gauge
+from pyecharts import options as opts
 
 
 @patch("pyecharts.render.engine.write_utf8_html_file")
@@ -12,3 +13,22 @@ def test_gauge_base(fake_writer):
     _, content = fake_writer.call_args[0]
     assert_equal(c.theme, "white")
     assert_equal(c.renderer, "canvas")
+
+
+@patch("pyecharts.render.engine.write_utf8_html_file")
+def test_gauage_label_setting(fake_writer):
+    c = (
+        Gauge()
+        .add(
+            "",
+            [("完成率", 66.6)],
+            detail_label_opts=opts.LabelOpts(formatter="{value}"),
+            title_label_opts=opts.LabelOpts(
+                font_size=40, color="blue", font_family="Microsoft YaHei"
+            ),
+        )
+        .render()
+    )
+    _, content = fake_writer.call_args[0]
+    assert_in("title", content)
+    assert_in("detail", content)


### PR DESCRIPTION
* 新增 gauge 的 title 配置 `title_label_opts
* 将原有的 `label_opts` 修改为 `detail_label_opts`

#### 注:
* `title_label_opts` 是用来控制轮盘内部文本的配置项。
* `detail_label_opts` 是用来控制轮盘内部数据的配置项。
* 文档待稍后进行更新

