### PR TITLE
update examples and options

### DIFF
--- a/example/bar3d_example.py
+++ b/example/bar3d_example.py
@@ -27,4 +27,102 @@ def bar3d_base() -> Bar3D:
     return c
 
 
+@C.funcs
+def bar3d_stack() -> Bar3D:
+    def generate_data():
+        data = []
+        for j in range(10):
+            for k in range(10):
+                value = random.randint(0, 9)
+                data.append([j, k, value * 2 + 4])
+        return data
+
+    c = (
+        Bar3D()
+        .add(
+            "",
+            generate_data(),
+            shading="lambert",
+            xaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
+            yaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
+            zaxis3d_opts=opts.Axis3DOpts(type_="value"),
+        )
+        .add(
+            "",
+            generate_data(),
+            shading="lambert",
+            xaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
+            yaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
+            zaxis3d_opts=opts.Axis3DOpts(type_="value"),
+        )
+        .add(
+            "",
+            generate_data(),
+            shading="lambert",
+            xaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
+            yaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
+            zaxis3d_opts=opts.Axis3DOpts(type_="value"),
+        )
+        .add(
+            "",
+            generate_data(),
+            shading="lambert",
+            xaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
+            yaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
+            zaxis3d_opts=opts.Axis3DOpts(type_="value"),
+        )
+        .add(
+            "",
+            generate_data(),
+            shading="lambert",
+            xaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
+            yaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
+            zaxis3d_opts=opts.Axis3DOpts(type_="value"),
+        )
+        .add(
+            "",
+            generate_data(),
+            shading="lambert",
+            xaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
+            yaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
+            zaxis3d_opts=opts.Axis3DOpts(type_="value"),
+        )
+        .add(
+            "",
+            generate_data(),
+            shading="lambert",
+            xaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
+            yaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
+            zaxis3d_opts=opts.Axis3DOpts(type_="value"),
+        )
+        .add(
+            "",
+            generate_data(),
+            shading="lambert",
+            xaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
+            yaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
+            zaxis3d_opts=opts.Axis3DOpts(type_="value"),
+        )
+        .add(
+            "",
+            generate_data(),
+            shading="lambert",
+            xaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
+            yaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
+            zaxis3d_opts=opts.Axis3DOpts(type_="value"),
+        )
+        .add(
+            "",
+            generate_data(),
+            shading="lambert",
+            xaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
+            yaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
+            zaxis3d_opts=opts.Axis3DOpts(type_="value"),
+        )
+        .set_global_opts(title_opts=opts.TitleOpts("Bar3D-堆叠柱状图示例"))
+        .set_series_opts(**{"stack": "stack"})
+    )
+    return c
+
+
 Page().add(*[fn() for fn, _ in C.charts]).render()

--- a/example/bar3d_example.py
+++ b/example/bar3d_example.py
@@ -7,6 +7,15 @@ from pyecharts.faker import Collector, Faker
 C = Collector()
 
 
+def generate_data():
+    data = []
+    for j in range(10):
+        for k in range(10):
+            value = random.randint(0, 9)
+            data.append([j, k, value * 2 + 4])
+    return data
+
+
 @C.funcs
 def bar3d_base() -> Bar3D:
     data = [(i, j, random.randint(0, 12)) for i in range(6) for j in range(24)]
@@ -29,100 +38,20 @@ def bar3d_base() -> Bar3D:
 
 @C.funcs
 def bar3d_stack() -> Bar3D:
-    def generate_data():
-        data = []
-        for j in range(10):
-            for k in range(10):
-                value = random.randint(0, 9)
-                data.append([j, k, value * 2 + 4])
-        return data
-
-    c = (
-        Bar3D()
-        .add(
+    x_data = y_data = list(range(10))
+    bar3d = Bar3D()
+    for _ in range(10):
+        bar3d.add(
             "",
             generate_data(),
             shading="lambert",
-            xaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
-            yaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
+            xaxis3d_opts=opts.Axis3DOpts(data=x_data, type_="value"),
+            yaxis3d_opts=opts.Axis3DOpts(data=y_data, type_="value"),
             zaxis3d_opts=opts.Axis3DOpts(type_="value"),
         )
-        .add(
-            "",
-            generate_data(),
-            shading="lambert",
-            xaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
-            yaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
-            zaxis3d_opts=opts.Axis3DOpts(type_="value"),
-        )
-        .add(
-            "",
-            generate_data(),
-            shading="lambert",
-            xaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
-            yaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
-            zaxis3d_opts=opts.Axis3DOpts(type_="value"),
-        )
-        .add(
-            "",
-            generate_data(),
-            shading="lambert",
-            xaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
-            yaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
-            zaxis3d_opts=opts.Axis3DOpts(type_="value"),
-        )
-        .add(
-            "",
-            generate_data(),
-            shading="lambert",
-            xaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
-            yaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
-            zaxis3d_opts=opts.Axis3DOpts(type_="value"),
-        )
-        .add(
-            "",
-            generate_data(),
-            shading="lambert",
-            xaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
-            yaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
-            zaxis3d_opts=opts.Axis3DOpts(type_="value"),
-        )
-        .add(
-            "",
-            generate_data(),
-            shading="lambert",
-            xaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
-            yaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
-            zaxis3d_opts=opts.Axis3DOpts(type_="value"),
-        )
-        .add(
-            "",
-            generate_data(),
-            shading="lambert",
-            xaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
-            yaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
-            zaxis3d_opts=opts.Axis3DOpts(type_="value"),
-        )
-        .add(
-            "",
-            generate_data(),
-            shading="lambert",
-            xaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
-            yaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
-            zaxis3d_opts=opts.Axis3DOpts(type_="value"),
-        )
-        .add(
-            "",
-            generate_data(),
-            shading="lambert",
-            xaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
-            yaxis3d_opts=opts.Axis3DOpts(data=list(range(10)), type_="value"),
-            zaxis3d_opts=opts.Axis3DOpts(type_="value"),
-        )
-        .set_global_opts(title_opts=opts.TitleOpts("Bar3D-堆叠柱状图示例"))
-        .set_series_opts(**{"stack": "stack"})
-    )
-    return c
+    bar3d.set_global_opts(title_opts=opts.TitleOpts("Bar3D-堆叠柱状图示例"))
+    bar3d.set_series_opts(**{"stack": "stack"})
+    return bar3d
 
 
 Page().add(*[fn() for fn, _ in C.charts]).render()

--- a/example/bar_example.py
+++ b/example/bar_example.py
@@ -542,4 +542,39 @@ def bar_custom_bar_color() -> Bar:
     return c
 
 
+@C.funcs
+def stack_bar_percent() -> Bar:
+    list2 = [
+        {"value": 12, "percent": 12 / (12 + 3)},
+        {"value": 23, "percent": 23 / (23 + 21)},
+        {"value": 33, "percent": 33 / (33 + 5)},
+        {"value": 3, "percent": 3 / (3 + 52)},
+        {"value": 33, "percent": 33 / (33 + 43)},
+    ]
+
+    list3 = [
+        {"value": 3, "percent": 3 / (12 + 3)},
+        {"value": 21, "percent": 21 / (23 + 21)},
+        {"value": 5, "percent": 5 / (33 + 5)},
+        {"value": 52, "percent": 52 / (3 + 52)},
+        {"value": 43, "percent": 43 / (33 + 43)},
+    ]
+
+    c = (
+        Bar(init_opts=opts.InitOpts(theme=ThemeType.LIGHT))
+        .add_xaxis([1, 2, 3, 4, 5])
+        .add_yaxis("product1", list2, stack="stack1", category_gap="50%")
+        .add_yaxis("product2", list3, stack="stack1", category_gap="50%")
+        .set_series_opts(
+            label_opts=opts.LabelOpts(
+                position="right",
+                formatter=JsCode(
+                    "function(x){return Number(x.data.percent * 100).toFixed() + '%';}"
+                ),
+            )
+        )
+    )
+    return c
+
+
 Page().add(*[fn() for fn, _ in C.charts]).render()

--- a/pyecharts/charts/basic_charts/geo.py
+++ b/pyecharts/charts/basic_charts/geo.py
@@ -127,6 +127,7 @@ class GeoChartBase(Chart):
                     "lineStyle": linestyle_opts,
                     "tooltip": tooltip_opts,
                     "itemStyle": itemstyle_opts,
+                    "label": label_opts,
                 }
             )
 

--- a/pyecharts/options/global_options.py
+++ b/pyecharts/options/global_options.py
@@ -284,6 +284,8 @@ class VisualMapOpts(BasicOpts):
         is_piecewise: bool = False,
         pieces: Optional[Sequence] = None,
         out_of_range: Optional[Sequence] = None,
+        item_width: int = 0,
+        item_height: int = 0,
         textstyle_opts: Union[TextStyleOpts, dict, None] = None,
     ):
         _inrange_op: dict = {}
@@ -295,6 +297,11 @@ class VisualMapOpts(BasicOpts):
             _inrange_op.update(symbolSize=range_size)
 
         _visual_typ = "piecewise" if is_piecewise else "continuous"
+
+        if is_piecewise and item_width == 0 and item_height == 0:
+            item_width, item_height = 20, 14
+        elif item_width == 0 and item_height == 0:
+            item_width, item_height = 20, 140
 
         self.opts: dict = {
             "show": is_show,
@@ -314,6 +321,8 @@ class VisualMapOpts(BasicOpts):
             "bottom": pos_bottom,
             "right": pos_right,
             "showLabel": True,
+            "itemWidth": item_width,
+            "itemHeight": item_height,
             "outOfRange": out_of_range,
         }
         if is_piecewise:

--- a/pyecharts/options/global_options.py
+++ b/pyecharts/options/global_options.py
@@ -247,7 +247,14 @@ class LegendOpts(BasicOpts):
         pos_top: Union[str, Numeric, None] = None,
         pos_bottom: Union[str, Numeric, None] = None,
         orient: Optional[str] = None,
+        align: Optional[str] = None,
+        padding: int = 5,
+        item_gap: int = 10,
+        item_width: int = 25,
+        item_height: int = 14,
+        inactive_color: Optional[str] = None,
         textstyle_opts: Union[TextStyleOpts, dict, None] = None,
+        legend_icon: Optional[str] = None,
     ):
         self.opts: dict = {
             "type": type_,
@@ -258,7 +265,14 @@ class LegendOpts(BasicOpts):
             "top": pos_top,
             "bottom": pos_bottom,
             "orient": orient,
+            "align": align,
+            "padding": padding,
+            "itemGap": item_gap,
+            "itemWidth": item_width,
+            "itemHeight": item_height,
+            "inactiveColor": inactive_color,
             "textStyle": textstyle_opts,
+            "icon": legend_icon,
         }
 
 

--- a/test/test_bar3d.py
+++ b/test/test_bar3d.py
@@ -1,7 +1,7 @@
 import random
 from unittest.mock import patch
 
-from nose.tools import assert_equal
+from nose.tools import assert_equal, assert_in
 
 from pyecharts import options as opts
 from pyecharts.charts import Bar3D
@@ -26,3 +26,31 @@ def test_bar3d_base(fake_writer):
     _, content = fake_writer.call_args[0]
     assert_equal(c.theme, "white")
     assert_equal(c.renderer, "canvas")
+
+
+@patch("pyecharts.render.engine.write_utf8_html_file")
+def test_bar3d_stack(fake_writer):
+    data1 = [(i, j, random.randint(0, 12)) for i in range(6) for j in range(24)]
+    data2 = [(i, j, random.randint(13, 20)) for i in range(6) for j in range(24)]
+    c = (
+        Bar3D()
+        .add(
+            "1",
+            [[d[1], d[0], d[2]] for d in data1],
+            xaxis3d_opts=opts.Axis3DOpts(Faker.clock, type_="category"),
+            yaxis3d_opts=opts.Axis3DOpts(Faker.week_en, type_="category"),
+            zaxis3d_opts=opts.Axis3DOpts(type_="value"),
+        )
+        .add(
+            "2",
+            [[d[1], d[0], d[2]] for d in data2],
+            xaxis3d_opts=opts.Axis3DOpts(Faker.clock, type_="category"),
+            yaxis3d_opts=opts.Axis3DOpts(Faker.week_en, type_="category"),
+            zaxis3d_opts=opts.Axis3DOpts(type_="value"),
+        )
+        .set_global_opts(visualmap_opts=opts.VisualMapOpts(max_=20))
+        .set_series_opts(**{"stack": "stack"})
+    )
+    c.render()
+    _, content = fake_writer.call_args[0]
+    assert_in("stack", content)

--- a/test/test_global_options.py
+++ b/test/test_global_options.py
@@ -1,7 +1,59 @@
 from nose.tools import assert_equal
 
 from pyecharts.commons.utils import remove_key_with_none_value
-from pyecharts.options.global_options import ToolboxOpts
+from pyecharts.options.global_options import (
+    AnimationOpts,
+    InitOpts,
+    ToolBoxFeatureOpts,
+    ToolboxOpts,
+    BrushOpts,
+    DataZoomOpts,
+    LegendOpts,
+    VisualMapOpts,
+    TooltipOpts,
+)
+
+
+def test_animation_options_remove_none():
+    option = AnimationOpts()
+    expected = {
+        "animation": True,
+        "animationDelay": 0,
+        "animationDelayUpdate": 0,
+        "animationDuration": 1000,
+        "animationDurationUpdate": 300,
+        "animationEasing": "cubicOut",
+        "animationEasingUpdate": "cubicOut",
+        "animationThreshold": 2000,
+    }
+    assert_equal(expected, remove_key_with_none_value(option.opts))
+
+
+def test_init_options_remove_none():
+    option = InitOpts(animation_opts={})
+    expected = {
+        "animationOpts": {},
+        "height": "500px",
+        "page_title": "Awesome-pyecharts",
+        "renderer": "canvas",
+        "theme": "white",
+        "width": "900px",
+    }
+    assert_equal(expected, remove_key_with_none_value(option.opts))
+
+
+def test_toolbox_feature_options_remove_none():
+    option = ToolBoxFeatureOpts()
+    expected = {
+        "dataView": {"readOnly": False, "show": True, "title": "data view"},
+        "dataZoom": {
+            "show": True,
+            "title": {"back": "data zoom restore", "zoom": "data zoom"},
+        },
+        "restore": {"show": True, "title": "restore"},
+        "saveAsImage": {"show": True, "title": "save as image", "type": "png"},
+    }
+    assert_equal(expected, remove_key_with_none_value(option.opts))
 
 
 def test_toolbox_options_remove_none():
@@ -13,5 +65,80 @@ def test_toolbox_options_remove_none():
         "itemGap": 10,
         "left": "80%",
         "feature": {},
+    }
+    assert_equal(expected, remove_key_with_none_value(option.opts))
+
+
+def test_brush_options_remove_none():
+    option = BrushOpts()
+    expected = {
+        "brushMode": "single",
+        "brushStyle": {
+            "borderColor": "rgba(120,140,180,0.8)",
+            "borderWidth": 1,
+            "color": "rgba(120,140,180,0.3)",
+        },
+        "brushType": "rect",
+        "removeOnClick": True,
+        "throttleDelay": 0,
+        "throttleType": "fixRate",
+        "toolbox": ["rect", "polygon", "keep", "clear"],
+        "transformable": True,
+    }
+    assert_equal(expected, remove_key_with_none_value(option.opts))
+
+
+def test_data_zoom_options_remove_none():
+    option = DataZoomOpts()
+    expected = {
+        "end": 80,
+        "orient": "horizontal",
+        "realtime": True,
+        "show": True,
+        "start": 20,
+        "type": "slider",
+        "zoomLock": False,
+    }
+    assert_equal(expected, remove_key_with_none_value(option.opts))
+
+
+def test_legend_options_remove_none():
+    option = LegendOpts()
+    expected = {
+        "show": True,
+        "padding": 5,
+        "itemGap": 10,
+        "itemWidth": 25,
+        "itemHeight": 14,
+    }
+    assert_equal(expected, remove_key_with_none_value(option.opts))
+
+
+def test_visual_map_options_remove_none():
+    option = VisualMapOpts()
+    expected = {
+        "calculable": True,
+        "inRange": {"color": ["#50a3ba", "#eac763", "#d94e5d"]},
+        "itemHeight": 140,
+        "itemWidth": 20,
+        "max": 100,
+        "min": 0,
+        "orient": "vertical",
+        "show": True,
+        "showLabel": True,
+        "splitNumber": 5,
+        "type": "continuous",
+    }
+    assert_equal(expected, remove_key_with_none_value(option.opts))
+
+
+def test_tool_tip_options_remove_none():
+    option = TooltipOpts(textstyle_opts=None)
+    expected = {
+        "axisPointer": {"type": "line"},
+        "borderWidth": 0,
+        "show": True,
+        "trigger": "item",
+        "triggerOn": "mousemove|click",
     }
     assert_equal(expected, remove_key_with_none_value(option.opts))


### PR DESCRIPTION
* 补充 `LegendOpts` 设置图例的 icon，大小，宽度，间隔以及未激活的颜色
* 补充 `VisualMapOpts` 设置 `itemWidth` 和 `itemHeight` 的设置（针对连续性和分段进行了处理）
* 补充 `Geo` 图的 `ChartType` 为 `Lines` 无法设置弧线上的 `label`
* 新增 `bar3D` 图的堆叠示例
* 新增 `bar` 图堆叠显示百分比的示例