### PR TITLE
Fix: Timeline 组合 Sankey 渲染 (Issue: #1407)

### DIFF
--- a/example/timeline_example.py
+++ b/example/timeline_example.py
@@ -84,12 +84,20 @@ def timeline_sankey() -> Timeline:
             {"source": names[1], "target": names[2], "value": Faker.values()[0]},
         ]
         sankey = (
-            Sankey() .add(
-                "sankey", nodes, links, linestyle_opt=opts.LineStyleOpts(
-                    opacity=0.2, curve=0.5, color="source"), label_opts=opts.LabelOpts(
-                    position="right")) .set_global_opts(
-                title_opts=opts.TitleOpts(
-                    title="{}年商店（A, B, C）营业额差".format(i))))
+            Sankey()
+            .add(
+                "sankey",
+                nodes,
+                links,
+                linestyle_opt=opts.LineStyleOpts(
+                    opacity=0.2, curve=0.5, color="source"
+                ),
+                label_opts=opts.LabelOpts(position="right"),
+            )
+            .set_global_opts(
+                title_opts=opts.TitleOpts(title="{}年商店（A, B, C）营业额差".format(i))
+            )
+        )
         tl.add(sankey, "{}年".format(i))
     return tl
 

--- a/example/timeline_example.py
+++ b/example/timeline_example.py
@@ -1,5 +1,5 @@
 from pyecharts import options as opts
-from pyecharts.charts import Bar, Map, Page, Pie, Timeline
+from pyecharts.charts import Bar, Map, Page, Pie, Sankey, Timeline
 from pyecharts.faker import Collector, Faker
 
 C = Collector()
@@ -59,7 +59,7 @@ def timeline_map() -> Timeline:
 
 
 @C.funcs
-def timeline_with_multi_axis():
+def timeline_with_multi_axis() -> Timeline:
     tl = Timeline()
     for i in range(2015, 2020):
         bar = (
@@ -70,6 +70,27 @@ def timeline_with_multi_axis():
             .set_global_opts(title_opts=opts.TitleOpts("某商店{}年营业额".format(i)))
         )
         tl.add(bar, "{}年".format(i))
+    return tl
+
+
+@C.funcs
+def timeline_sankey() -> Timeline:
+    tl = Timeline()
+    names = ("商家A", "商家B", "商家C")
+    nodes = [{"name": name} for name in names]
+    for i in range(2015, 2020):
+        links = [
+            {"source": names[0], "target": names[1], "value": Faker.values()[0]},
+            {"source": names[1], "target": names[2], "value": Faker.values()[0]},
+        ]
+        sankey = (
+            Sankey() .add(
+                "sankey", nodes, links, linestyle_opt=opts.LineStyleOpts(
+                    opacity=0.2, curve=0.5, color="source"), label_opts=opts.LabelOpts(
+                    position="right")) .set_global_opts(
+                title_opts=opts.TitleOpts(
+                    title="{}年商店（A, B, C）营业额差".format(i))))
+        tl.add(sankey, "{}年".format(i))
     return tl
 
 

--- a/pyecharts/charts/composite_charts/timeline.py
+++ b/pyecharts/charts/composite_charts/timeline.py
@@ -68,7 +68,7 @@ class Timeline(Base):
             self.js_dependencies.add(dep)
         self._time_points.append(time_point)
 
-        series_data = [{"data": s.get("data")} for s in chart.options.get("series")]
+        series_data = chart.options.get("series")
         self.options.get("baseOption").get("timeline").update(data=self._time_points)
         self.options.get("options").append(
             {

--- a/pyecharts/charts/composite_charts/timeline.py
+++ b/pyecharts/charts/composite_charts/timeline.py
@@ -68,12 +68,11 @@ class Timeline(Base):
             self.js_dependencies.add(dep)
         self._time_points.append(time_point)
 
-        series_data = chart.options.get("series")
         self.options.get("baseOption").get("timeline").update(data=self._time_points)
         self.options.get("options").append(
             {
                 "legend": chart.options.get("legend"),
-                "series": series_data,
+                "series": chart.options.get("series"),
                 "xAxis": chart.options.get("xAxis"),
                 "title": chart.options.get("title"),
                 "tooltip": chart.options.get("tooltip"),


### PR DESCRIPTION
<!--

### 提 PR 注意事项
0. 同步到 dev 分支的最新版本
1. 代码尽量保持与项目统一风格，尽量按照 PEP8 规范写代码，必要时附上注释
2. 如需要时请添加单元测试，也请确保所有测试能够通过
3. 将 PR 推送至远程的 dev 分支，master 分支只负责发布新版本。请在提交信息中描述关于该 PR 的详细信息，需要时加上截图。
4. 若是对文档进行修改，请确保数字，字母与中文之间两边均有一空格，如你所看到的所有文档一样

-->

本次 PR 内容，

### 修复 [Issue: #1407](https://github.com/pyecharts/pyecharts/issues/1407) -  Timeline 组合 Sankey 渲染只有最后一个时间点的桑基图

* 修复 Timeline 组合 Sankey 渲染只有最后一个时间点的桑基图
* 并添加 Timeline 组合 Sankey 样例代码
![issue#1407](https://user-images.githubusercontent.com/54145886/68931246-1d53ad00-07cb-11ea-9d8e-b1c5efdb3415.gif)

