### PR TITLE
doc: remove incubating and incubator from Apache ECharts in README

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -36,7 +36,7 @@
 
 ## 📣 Introduction
 
-[Apache ECharts (incubating)](https://github.com/apache/incubator-echarts) is easy-to-use, highly interactive and highly performant javascript visualization library under Apache license. Since its first public release in 2013, it now dominates over 74% of Chinese web front-end market. Yet Python is an expressive language and is loved by data science community. Combining the strength of both technologies, [pyecharts](https://github.com/pyecharts/pyecharts) is born.
+[Apache ECharts](https://github.com/apache/echarts) is easy-to-use, highly interactive and highly performant javascript visualization library under Apache license. Since its first public release in 2013, it now dominates over 74% of Chinese web front-end market. Yet Python is an expressive language and is loved by data science community. Combining the strength of both technologies, [pyecharts](https://github.com/pyecharts/pyecharts) is born.
 
 ## ✨ Feature highlights
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 
 ## 📣 简介
 
-[Apache ECharts (incubating)](https://github.com/apache/incubator-echarts) 是一个由百度开源的数据可视化，凭借着良好的交互性，精巧的图表设计，得到了众多开发者的认可。而 Python 是一门富有表达力的语言，很适合用于数据处理。当数据分析遇上数据可视化时，[pyecharts](https://github.com/pyecharts/pyecharts) 诞生了。
+[Apache ECharts](https://github.com/apache/echarts) 是一个由百度开源的数据可视化，凭借着良好的交互性，精巧的图表设计，得到了众多开发者的认可。而 Python 是一门富有表达力的语言，很适合用于数据处理。当数据分析遇上数据可视化时，[pyecharts](https://github.com/pyecharts/pyecharts) 诞生了。
 
 ## ✨ 特性
 


### PR DESCRIPTION
Hi, the pyecharts team,

Apache ECharts graduated on 2020-12-16 [1].
I'm opening this PR to remove `incubating` and `incubator` words in README files.

Thanks!

[1] https://incubator.apache.org/projects/echarts.html
