### PR TITLE
fix bug of _append_color

### DIFF
--- a/pyecharts/charts/chart.py
+++ b/pyecharts/charts/chart.py
@@ -17,6 +17,7 @@ class Chart(Base):
             "#546570 #c4ccd3 #f05b72 #ef5b9c #f47920 #905a3d #fab27b #2a5caa "
             "#444693 #726930 #b2d235 #6d8346 #ac6767 #1d953f #6950a1 #918597"
         ).split()
+        self.default_color_n = len(self.colors)
         if init_opts.opts.get("theme") == ThemeType.WHITE:
             self.options.update(color=self.colors)
         self.options.update(
@@ -90,7 +91,9 @@ class Chart(Base):
 
     def _append_color(self, color: Optional[str]):
         if color:
-            self.colors = [color] + self.colors
+            # 这是一个bug
+            # 添加轴（执行add_yaxis操作）的顺序与新添加的color值（设置color属性）未一一对应，正好颠倒
+            self.colors.insert(-self.default_color_n, color)
             if self.theme == ThemeType.WHITE:
                 self.options.update(color=self.colors)
 

--- a/test/test_chart.py
+++ b/test/test_chart.py
@@ -1,0 +1,29 @@
+from nose.tools import assert_equal
+from pyecharts.charts import Line
+
+
+def test_chart_append_color():
+    x_data = ["周一", "周二", "周三", "周四", "周五", "周六", "周日"]
+    y_data1 = [140, 232, 101, 264, 90, 340, 250]
+    y_data2 = [120, 282, 111, 234, 220, 340, 310]
+
+    c = (
+        Line()
+            .add_xaxis(xaxis_data=x_data)
+            .add_yaxis(
+            series_name="品类 1",
+            y_axis=y_data1,
+            color='#80FFA5')
+            .add_yaxis(
+            series_name="品类 2",
+            y_axis=y_data2,
+            color='#00DDFF')
+    )
+    c.render()
+    default_colors = (
+        "#c23531 #2f4554 #61a0a8 #d48265 #749f83 #ca8622 #bda29a #6e7074 "
+        "#546570 #c4ccd3 #f05b72 #ef5b9c #f47920 #905a3d #fab27b #2a5caa "
+        "#444693 #726930 #b2d235 #6d8346 #ac6767 #1d953f #6950a1 #918597"
+    ).split()
+    expected_result = ['#80FFA5', '#00DDFF', *default_colors]
+    assert_equal(c.colors, expected_result)


### PR DESCRIPTION
<!--

### 提 PR 注意事项
0. 同步到 dev 分支的最新版本
1. 代码尽量保持与项目统一风格，尽量按照 PEP8 规范写代码，必要时附上注释
2. 如需要时请添加单元测试，也请确保所有测试能够通过
3. 将 PR 推送至远程的 dev 分支，master 分支只负责发布新版本。请在提交信息中描述关于该 PR 的详细信息，需要时加上截图。
4. 若是对文档进行修改，请确保数字，字母与中文之间两边均有一空格，如你所看到的所有文档一样

-->

本次 PR 内容，

1. 问题描述
chart.py 模块，_append_color方法，添加轴（执行add_yaxis操作）的顺序与新添加的color值（设置color属性）未一一对应，正好被颠倒。

2. 重现这个bug
`
x_data = ["周一", "周二", "周三", "周四", "周五", "周六", "周日"]
y_data1 = [140, 232, 101, 264, 90, 340, 250]
y_data2 = [120, 282, 111, 234, 220, 340, 310]
y_data3 = [320, 132, 201, 334, 190, 130, 220]

(
      Line()
          .add_xaxis(xaxis_data=x_data)
          .add_yaxis(
          series_name="品类 1",
           y_axis=y_data1,
          color='#80FFA5')
       .add_yaxis(
          series_name="品类 2",
          y_axis=y_data2,
          color='#00DDFF')
  )
`

在现有版本下跑，品类 1的颜色被错误标记为：#00DDFF，品类 2的颜色为：#80FFA5

3 我提交的版本可以修复这个问题，请查看或讨论。谢谢。



