### PR TITLE
support dispatch actions

### DIFF
--- a/pyecharts/charts/base.py
+++ b/pyecharts/charts/base.py
@@ -51,6 +51,7 @@ class Base(ChartMixin):
         self.render_options: dict = {}
         self.js_host: str = _opts.get("js_host") or CurrentConfig.ONLINE_HOST
         self.js_functions: utils.OrderedSet = utils.OrderedSet()
+        self.dispatch_actions: utils.OrderedSet = utils.OrderedSet()
         self.js_dependencies: utils.OrderedSet = utils.OrderedSet("echarts")
         self.options.update(backgroundColor=self.bg_color)
         if isinstance(_opts.get("animationOpts", AnimationOpts()), dict):

--- a/pyecharts/charts/mixins.py
+++ b/pyecharts/charts/mixins.py
@@ -7,6 +7,11 @@ class ChartMixin:
             self.js_functions.add(fn)
         return self
 
+    def add_dispatch_actions(self, *actions):
+        for action in actions:
+            self.dispatch_actions.add(action)
+        return self
+
     def load_javascript(self):
         return engine.load_javascript(self)
 

--- a/pyecharts/render/templates/macro
+++ b/pyecharts/render/templates/macro
@@ -42,6 +42,11 @@
         {% endfor %}
         var option_{{ c.chart_id }} = {{ c.json_contents }};
         chart_{{ c.chart_id }}.setOption(option_{{ c.chart_id }});
+        {% for action in c.dispatch_actions.items %}
+            chart_{{ c.chart_id }}.dispatchAction(
+                {{ action }}
+            );
+        {% endfor %}
         {% if c._is_geo_chart %}
             var bmap = chart_{{ c.chart_id }}.getModel().getComponent('bmap').getBMap();
             {% if c.bmap_js_functions %}
@@ -70,6 +75,11 @@
                 {% endfor %}
                 var option_{{ c.chart_id }} = {{ c.json_contents }};
                 chart_{{ c.chart_id }}.setOption(option_{{ c.chart_id }});
+                {% for action in c.dispatch_actions.items %}
+                    chart_{{ c.chart_id }}.dispatchAction(
+                        {{ action }}
+                    );
+                {% endfor %}
                 {% if c._is_geo_chart %}
                     var bmap = chart_{{ c.chart_id }}.getModel().getComponent('bmap').getBMap();
                     bmap.addControl(new BMap.MapTypeControl());


### PR DESCRIPTION
<!--

### 提 PR 注意事项
0. 同步到 dev 分支的最新版本
1. 代码尽量保持与项目统一风格，尽量按照 PEP8 规范写代码，必要时附上注释
2. 如需要时请添加单元测试，也请确保所有测试能够通过
3. 将 PR 推送至远程的 dev 分支，master 分支只负责发布新版本。请在提交信息中描述关于该 PR 的详细信息，需要时加上截图。
4. 若是对文档进行修改，请确保数字，字母与中文之间两边均有一空格，如你所看到的所有文档一样

-->

本次 PR 内容：

搜索了一下目前不支持echarts的dispatchAction，我想在chart render出来默认就brush一段x的范围，需要借助dispatchAction方法。尝试实现了，麻烦review。我对echarts的API不太熟，目前是采用裸写一个JS object字符串进去。

用法类似于
```python
brush_range = ('2023-01-01', '2023-01-30')
grid_chart.add_dispatch_actions(
        """{
    type: 'brush',
    areas: [
      {
        brushType: 'lineX',
        coordRange: ['%s', '%s'],
        xAxisIndex: 0
      }
    ]
}""" % (brush_range)  # use Python 2 string formating to avoid double curly braces
    )
```


