### PR TITLE
Fix grid index

### DIFF
--- a/pyecharts/charts/composite_charts/grid.py
+++ b/pyecharts/charts/composite_charts/grid.py
@@ -1,4 +1,5 @@
 import copy
+from typing import Optional
 
 from ... import options as opts
 from ... import types
@@ -30,7 +31,7 @@ class Grid(Base):
         chart: Chart,
         grid_opts: types.Union[opts.GridOpts, dict],
         *,
-        grid_index: int = 0,
+        grid_index: Optional[int] = None,
         is_control_axis_index: bool = False,
     ):
         if self.options is None:
@@ -96,7 +97,7 @@ class Grid(Base):
             self.options.update(geo=chart.options.get("geo"))
 
         if isinstance(chart, RectChart):
-            if grid_index == 0:
+            if grid_index is None:
                 grid_index = self._grow_grid_index
 
             for x in chart.options.get("xAxis"):

--- a/pyecharts/charts/composite_charts/grid.py
+++ b/pyecharts/charts/composite_charts/grid.py
@@ -100,10 +100,16 @@ class Grid(Base):
             if grid_index is None:
                 grid_index = self._grow_grid_index
 
-            for x in chart.options.get("xAxis"):
-                x.update(gridIndex=grid_index)
-            for y in chart.options.get("yAxis"):
-                y.update(gridIndex=grid_index)
+            if self._grow_grid_index == 0:
+                for x in self.options.get("xAxis"):
+                    x.update(gridIndex=grid_index) if x.get("gridIndex") is None else ...
+                for y in self.options.get("yAxis"):
+                    y.update(gridIndex=grid_index) if y.get("gridIndex") is None else ...
+            else:
+                for x in chart.options.get("xAxis"):
+                    x.update(gridIndex=grid_index) if x.get("gridIndex") is None else ...
+                for y in chart.options.get("yAxis"):
+                    y.update(gridIndex=grid_index) if y.get("gridIndex") is None else ...
             self._grow_grid_index += 1
 
         if self._axis_index > 0:

--- a/pyecharts/options/global_options.py
+++ b/pyecharts/options/global_options.py
@@ -844,7 +844,7 @@ class AxisOpts(BasicOpts):
         name_gap: Numeric = 15,
         name_rotate: Optional[Numeric] = None,
         interval: Optional[Numeric] = None,
-        grid_index: Numeric = 0,
+        grid_index: Optional[Numeric] = None,
         position: Optional[str] = None,
         offset: Numeric = 0,
         split_number: Numeric = 5,

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -136,7 +136,7 @@ class TestGridComponent(unittest.TestCase):
             .add(chart=bar_2, grid_index=2, grid_opts=opts.GridOpts())
             .add(chart=bar_3, grid_index=1, grid_opts=opts.GridOpts())
         )
-        expected_idx = (1, 0, 2)
+        expected_idx = (0, 2, 1)
         for idx, series in enumerate(gc.options.get("xAxis")):
             self.assertEqual(series.get("gridIndex"), expected_idx[idx])
 

--- a/test/test_grid.py
+++ b/test/test_grid.py
@@ -59,6 +59,18 @@ class TestGridComponent(unittest.TestCase):
         bar.overlap(line)
         return bar
 
+    def _chart_for_set_grid_index(self, gird_index=None) -> Bar:
+        bar = (
+            Bar()
+            .add_xaxis(Faker.choose())
+            .add_yaxis("商家A", Faker.values())
+            .set_global_opts(
+                xaxis_opts=opts.AxisOpts(grid_index=gird_index),
+                yaxis_opts=opts.AxisOpts(grid_index=gird_index)
+            )
+        )
+        return bar
+
     def _chart_for_grid_with_datazoom_and_visualmap(self) -> Bar:
         bar_1 = (
             Bar()
@@ -100,6 +112,74 @@ class TestGridComponent(unittest.TestCase):
             )
         )
         return bar_1
+
+    def test_grid_set_grid_index(self):
+        bar_1 = self._chart_for_set_grid_index()
+        bar_2 = self._chart_for_set_grid_index()
+        bar_3 = self._chart_for_set_grid_index()
+        gc = (
+            Grid()
+            .add(chart=bar_1, grid_index=1, grid_opts=opts.GridOpts())
+            .add(chart=bar_2, grid_index=0, grid_opts=opts.GridOpts())
+            .add(chart=bar_3, grid_index=2, grid_opts=opts.GridOpts())
+        )
+        expected_idx = (1, 0, 2)
+        for idx, series in enumerate(gc.options.get("xAxis")):
+            self.assertEqual(series.get("gridIndex"), expected_idx[idx])
+
+        bar_1 = self._chart_for_set_grid_index()
+        bar_2 = self._chart_for_set_grid_index()
+        bar_3 = self._chart_for_set_grid_index()
+        gc = (
+            Grid()
+            .add(chart=bar_1, grid_index=0, grid_opts=opts.GridOpts())
+            .add(chart=bar_2, grid_index=2, grid_opts=opts.GridOpts())
+            .add(chart=bar_3, grid_index=1, grid_opts=opts.GridOpts())
+        )
+        expected_idx = (1, 0, 2)
+        for idx, series in enumerate(gc.options.get("xAxis")):
+            self.assertEqual(series.get("gridIndex"), expected_idx[idx])
+
+    def test_grid_set_grid_index_priority(self):
+        bar_1 = self._chart_for_set_grid_index(gird_index=2)
+        bar_2 = self._chart_for_set_grid_index(gird_index=0)
+        bar_3 = self._chart_for_set_grid_index(gird_index=1)
+        gc = (
+            Grid()
+            .add(chart=bar_1, grid_index=1, grid_opts=opts.GridOpts())
+            .add(chart=bar_2, grid_index=2, grid_opts=opts.GridOpts())
+            .add(chart=bar_3, grid_index=0, grid_opts=opts.GridOpts())
+        )
+        expected_idx = (2, 0, 1)
+        for idx, series in enumerate(gc.options.get("xAxis")):
+            self.assertEqual(series.get("gridIndex"), expected_idx[idx])
+
+        bar_1 = self._chart_for_set_grid_index(gird_index=0)
+        bar_2 = self._chart_for_set_grid_index(gird_index=2)
+        bar_3 = self._chart_for_set_grid_index(gird_index=1)
+        gc = (
+            Grid()
+            .add(chart=bar_1, grid_index=2, grid_opts=opts.GridOpts())
+            .add(chart=bar_2, grid_index=1, grid_opts=opts.GridOpts())
+            .add(chart=bar_3, grid_index=0, grid_opts=opts.GridOpts())
+        )
+        expected_idx = (0, 2, 1)
+        for idx, series in enumerate(gc.options.get("xAxis")):
+            self.assertEqual(series.get("gridIndex"), expected_idx[idx])
+
+    def test_grid_set_grid_out_of_order(self):
+        bar_1 = self._chart_for_set_grid_index(gird_index=2)
+        bar_2 = self._chart_for_set_grid_index(gird_index=0)
+        bar_3 = self._chart_for_set_grid_index(gird_index=1)
+        gc = (
+            Grid()
+            .add(chart=bar_2, grid_index=1, grid_opts=opts.GridOpts())
+            .add(chart=bar_3, grid_index=2, grid_opts=opts.GridOpts())
+            .add(chart=bar_1, grid_index=0, grid_opts=opts.GridOpts())
+        )
+        expected_idx = (0, 1, 2)
+        for idx, series in enumerate(gc.options.get("xAxis")):
+            self.assertEqual(series.get("gridIndex"), expected_idx[idx])
 
     def test_grid_control_axis_index(self):
         bar = self._chart_for_grid()


### PR DESCRIPTION
- bug_fix
1. 修复当add_grid的顺序为乱序时，Gird.add(grid_index=xxx)设置失效的问题
2. 修复AxisOpts中设置的grid_index无效的问题。
---
- test_case
1. 添加在Gird.add中设置grid_index的有效性测试
2. 添加在不同位置设置grid_index的优先级测试
3. 添加在乱序调用Grid.add的情况下，grid_index设置有效性的测试