### PR TITLE
Fix `uv` warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,8 +52,8 @@ Homepage = "https://github.com/pyecharts/pyecharts"
 version_scheme = "guess-next-dev"
 local_scheme = "dirty-tag"
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "nose2",
     "codecov",
     "coverage",


### PR DESCRIPTION
```
warning: The `tool.uv.dev-dependencies` field (used in `pyproject.toml`) is deprecated and will be removed in a future release; use `dependency-groups.dev` instead
```


